### PR TITLE
Add volumeclaim claim - test-claim

### DIFF
--- a/claims/claims/test-claim/catalog-info.yaml
+++ b/claims/claims/test-claim/catalog-info.yaml
@@ -1,0 +1,18 @@
+---
+apiVersion: backstage.io/v1alpha1
+kind: Component
+metadata:
+  name: test-claim
+  description: Crossplane claim (volumeclaim) - test-claim
+  annotations:
+    github.com/project-slug: stuttgart-things/harvester
+    backstage.io/source-location: url:https://github.com/stuttgart-things/harvester/tree/main/claims
+    claim-machinery/template: volumeclaim
+  tags:
+    - crossplane
+    - claim
+    - volumeclaim
+spec:
+  type: crossplane-claim
+  lifecycle: production
+  owner: platform-team

--- a/claims/claims/volumeclaim.yaml
+++ b/claims/claims/volumeclaim.yaml
@@ -1,0 +1,16 @@
+apiVersion: resources.stuttgart-things.com/v1alpha1
+kind: VolumeClaim
+metadata:
+  name: app-data
+  namespace: default
+spec:
+  accessModes:
+  - ReadWriteOnce
+  annotations:
+    description: A simple persistent volume claim for application data
+  namespace: default
+  providerConfigRef: harvester
+  pvcName: app-data
+  storage: '20Gi'
+  storageClassName: harvester-longhorn
+  volumeMode: Filesystem


### PR DESCRIPTION
## Claim Manifest Created via Backstage

**Template**: volumeclaim
**Claim Name**: test-claim

### Manifest Details
```yaml
apiVersion: resources.stuttgart-things.com/v1alpha1
kind: VolumeClaim
metadata:
  name: app-data
  namespace: default
spec:
  accessModes:
  - ReadWriteOnce
  annotations:
    description: A simple persistent volume claim for application data
  namespace: default
  providerConfigRef: harvester
  pvcName: app-data
  storage: '20Gi'
  storageClassName: harvester-longhorn
  volumeMode: Filesystem

```

Created automatically via Backstage Claim Machinery integration.
