### PR TITLE
Add volumeclaim claim - test-claim2

### DIFF
--- a/claims/apps/test-claim2/claims/apps/test-claim2/catalog-info.yaml
+++ b/claims/apps/test-claim2/claims/apps/test-claim2/catalog-info.yaml
@@ -1,0 +1,20 @@
+---
+apiVersion: backstage.io/v1alpha1
+kind: Component
+metadata:
+  name: test-claim2
+  description: Crossplane claim (volumeclaim) - test-claim2
+  annotations:
+    github.com/project-slug: stuttgart-things/harvester
+    backstage.io/source-location: url:https://github.com/stuttgart-things/harvester/tree/main/claims/apps/test-claim2
+    claim-machinery/template: volumeclaim
+    claim-machinery/category: apps
+  tags:
+    - crossplane
+    - claim
+    - volumeclaim
+    - apps
+spec:
+  type: crossplane-claim
+  lifecycle: production
+  owner: platform-team

--- a/claims/apps/test-claim2/claims/apps/test-claim2/volumeclaim.yaml
+++ b/claims/apps/test-claim2/claims/apps/test-claim2/volumeclaim.yaml
@@ -1,0 +1,16 @@
+apiVersion: resources.stuttgart-things.com/v1alpha1
+kind: VolumeClaim
+metadata:
+  name: app-data
+  namespace: default
+spec:
+  accessModes:
+  - ReadWriteOnce
+  annotations:
+    description: A simple persistent volume claim for application data
+  namespace: default
+  providerConfigRef: in-cluster
+  pvcName: app-data
+  storage: '20Gi'
+  storageClassName: harvester-longhorn
+  volumeMode: Filesystem


### PR DESCRIPTION
## Claim Manifest Created via Backstage

**Template**: volumeclaim
**Resource Name**: test-claim2
**Category**: apps

### Manifest Details
```yaml
apiVersion: resources.stuttgart-things.com/v1alpha1
kind: VolumeClaim
metadata:
  name: app-data
  namespace: default
spec:
  accessModes:
  - ReadWriteOnce
  annotations:
    description: A simple persistent volume claim for application data
  namespace: default
  providerConfigRef: in-cluster
  pvcName: app-data
  storage: '20Gi'
  storageClassName: harvester-longhorn
  volumeMode: Filesystem

```

Created automatically via Backstage Claim Machinery integration.
