### PR TITLE
Add volumeclaim claim - app-pvc

### DIFF
--- a/claims/infra/app-pvc/catalog-info.yaml
+++ b/claims/infra/app-pvc/catalog-info.yaml
@@ -1,0 +1,20 @@
+---
+apiVersion: backstage.io/v1alpha1
+kind: Component
+metadata:
+  name: app-pvc
+  description: Crossplane claim (volumeclaim) - app-pvc
+  annotations:
+    github.com/project-slug: stuttgart-things/harvester
+    backstage.io/source-location: url:https://github.com/stuttgart-things/harvester/tree/main/claims/infra/app-pvc
+    claim-machinery/template: volumeclaim
+    claim-machinery/category: infra
+  tags:
+    - crossplane
+    - claim
+    - volumeclaim
+    - infra
+spec:
+  type: crossplane-claim
+  lifecycle: production
+  owner: platform-team

--- a/claims/infra/app-pvc/volumeclaim.yaml
+++ b/claims/infra/app-pvc/volumeclaim.yaml
@@ -1,0 +1,16 @@
+apiVersion: resources.stuttgart-things.com/v1alpha1
+kind: VolumeClaim
+metadata:
+  name: app-data
+  namespace: default
+spec:
+  accessModes:
+  - ReadWriteOnce
+  annotations:
+    description: A simple persistent volume claim for application data
+  namespace: default
+  providerConfigRef: harvester
+  pvcName: app-data
+  storage: '20Gi'
+  storageClassName: harvester-longhorn
+  volumeMode: Filesystem


### PR DESCRIPTION
## Claim Manifest Created via Backstage

**Template**: volumeclaim
**Resource Name**: app-pvc
**Category**: infra

### Manifest Details
```yaml
apiVersion: resources.stuttgart-things.com/v1alpha1
kind: VolumeClaim
metadata:
  name: app-data
  namespace: default
spec:
  accessModes:
  - ReadWriteOnce
  annotations:
    description: A simple persistent volume claim for application data
  namespace: default
  providerConfigRef: harvester
  pvcName: app-data
  storage: '20Gi'
  storageClassName: harvester-longhorn
  volumeMode: Filesystem

```

Created automatically via Backstage Claim Machinery integration.
