### PR TITLE
Add volumeclaim claim - abrechnungen

### DIFF
--- a/claims/other-resources/abrechnungen/catalog-info.yaml
+++ b/claims/other-resources/abrechnungen/catalog-info.yaml
@@ -1,0 +1,20 @@
+---
+apiVersion: backstage.io/v1alpha1
+kind: Component
+metadata:
+  name: abrechnungen
+  description: Crossplane claim (volumeclaim) - abrechnungen
+  annotations:
+    github.com/project-slug: stuttgart-things/harvester
+    backstage.io/source-location: url:https://github.com/stuttgart-things/harvester/tree/main/claims/other-resources/abrechnungen
+    claim-machinery/template: volumeclaim
+    claim-machinery/category: other-resources
+  tags:
+    - crossplane
+    - claim
+    - volumeclaim
+    - other-resources
+spec:
+  type: crossplane-claim
+  lifecycle: production
+  owner: platform-team

--- a/claims/other-resources/abrechnungen/volumeclaim.yaml
+++ b/claims/other-resources/abrechnungen/volumeclaim.yaml
@@ -1,0 +1,16 @@
+apiVersion: resources.stuttgart-things.com/v1alpha1
+kind: VolumeClaim
+metadata:
+  name: app-data
+  namespace: default
+spec:
+  accessModes:
+  - ReadWriteOnce
+  annotations:
+    description: A simple persistent volume claim for application data
+  namespace: default
+  providerConfigRef: harvester
+  pvcName: app-data
+  storage: '5Gi'
+  storageClassName: harvester-longhorn
+  volumeMode: Filesystem


### PR DESCRIPTION
## Claim Manifest Created via Backstage

**Template**: volumeclaim
**Resource Name**: abrechnungen
**Category**: other-resources

### Manifest Details
```yaml
apiVersion: resources.stuttgart-things.com/v1alpha1
kind: VolumeClaim
metadata:
  name: app-data
  namespace: default
spec:
  accessModes:
  - ReadWriteOnce
  annotations:
    description: A simple persistent volume claim for application data
  namespace: default
  providerConfigRef: harvester
  pvcName: app-data
  storage: '5Gi'
  storageClassName: harvester-longhorn
  volumeMode: Filesystem

```

Created automatically via Backstage Claim Machinery integration.
