### PR TITLE
Add harvestervm-developer claim - kubernetes-vm

### DIFF
--- a/claims/infra/kubernetes-vm/catalog-info.yaml
+++ b/claims/infra/kubernetes-vm/catalog-info.yaml
@@ -1,0 +1,20 @@
+---
+apiVersion: backstage.io/v1alpha1
+kind: Component
+metadata:
+  name: kubernetes-vm
+  description: Crossplane claim (harvestervm-developer) - kubernetes-vm
+  annotations:
+    github.com/project-slug: stuttgart-things/harvester
+    backstage.io/source-location: url:https://github.com/stuttgart-things/harvester/tree/main/claims/infra/kubernetes-vm
+    claim-machinery/template: harvestervm-developer
+    claim-machinery/category: infra
+  tags:
+    - crossplane
+    - claim
+    - harvestervm-developer
+    - infra
+spec:
+  type: crossplane-claim
+  lifecycle: production
+  owner: platform-team

--- a/claims/infra/kubernetes-vm/harvestervm-developer.yaml
+++ b/claims/infra/kubernetes-vm/harvestervm-developer.yaml
@@ -1,0 +1,45 @@
+apiVersion: resources.stuttgart-things.com/v1alpha1
+kind: HarvesterVM
+metadata:
+  name: kubernetes-vm
+  namespace: default
+spec:
+  providerConfigRef: dev
+  volume:
+    pvcName: kubernetes-vm-root
+    namespace: default
+    storageClassName: harvester-longhorn
+    storage: '10Gi'
+    accessModes:
+    - ReadWriteOnce
+    volumeMode: Filesystem
+  cloudInit:
+    vmName: kubernetes-vm
+    namespace: vms
+    hostname: kubernetes
+    domain: local
+    packageUpdate: true
+    packageUpgrade: false
+    sshPasswordAuth: false
+    disableRoot: true
+  vm:
+    runStrategy: RerunOnFailure
+    evictionStrategy: LiveMigrateIfPossible
+    terminationGracePeriodSeconds: 120
+    os: ubuntu
+    machineType: q35
+    cpu:
+      cores: 8
+      sockets: 1
+      threads: 1
+    resources:
+      memory: '8Gi'
+      cpu: '8'
+    disks:
+    - name: rootdisk
+      bus: virtio
+    - name: cloudinitdisk
+      bus: virtio
+    networks:
+    - name: default
+      networkName: default/default

--- a/claims/infra/kubernetes-vm/kustomization.yaml
+++ b/claims/infra/kubernetes-vm/kustomization.yaml
@@ -1,0 +1,5 @@
+---
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - harvestervm-developer.yaml


### PR DESCRIPTION
## Claim Manifest Created via Backstage

**Template**: harvestervm-developer
**Resource Name**: kubernetes-vm
**Category**: infra

### Manifest Details
```yaml
apiVersion: resources.stuttgart-things.com/v1alpha1
kind: HarvesterVM
metadata:
  name: kubernetes-vm
  namespace: default
spec:
  providerConfigRef: dev
  volume:
    pvcName: kubernetes-vm-root
    namespace: default
    storageClassName: harvester-longhorn
    storage: '10Gi'
    accessModes:
    - ReadWriteOnce
    volumeMode: Filesystem
  cloudInit:
    vmName: kubernetes-vm
    namespace: vms
    hostname: kubernetes
    domain: local
    packageUpdate: true
    packageUpgrade: false
    sshPasswordAuth: false
    disableRoot: true
  vm:
    runStrategy: RerunOnFailure
    evictionStrategy: LiveMigrateIfPossible
    terminationGracePeriodSeconds: 120
    os: ubuntu
    machineType: q35
    cpu:
      cores: 8
      sockets: 1
      threads: 1
    resources:
      memory: '8Gi'
      cpu: '8'
    disks:
    - name: rootdisk
      bus: virtio
    - name: cloudinitdisk
      bus: virtio
    networks:
    - name: default
      networkName: default/default

```

Created automatically via Backstage Claim Machinery integration.
