### PR TITLE
Add harvestervm-developer claim - martin-kubernetes

### DIFF
--- a/claims/infra/martin-kubernetes/catalog-info.yaml
+++ b/claims/infra/martin-kubernetes/catalog-info.yaml
@@ -1,0 +1,20 @@
+---
+apiVersion: backstage.io/v1alpha1
+kind: Component
+metadata:
+  name: martin-kubernetes
+  description: Crossplane claim (harvestervm-developer) - martin-kubernetes
+  annotations:
+    github.com/project-slug: stuttgart-things/harvester
+    backstage.io/source-location: url:https://github.com/stuttgart-things/harvester/tree/main/claims/infra/martin-kubernetes
+    claim-machinery/template: harvestervm-developer
+    claim-machinery/category: infra
+  tags:
+    - crossplane
+    - claim
+    - harvestervm-developer
+    - infra
+spec:
+  type: crossplane-claim
+  lifecycle: production
+  owner: platform-team

--- a/claims/infra/martin-kubernetes/harvestervm-developer.yaml
+++ b/claims/infra/martin-kubernetes/harvestervm-developer.yaml
@@ -1,0 +1,50 @@
+apiVersion: resources.stuttgart-things.com/v1alpha1
+kind: HarvesterVM
+metadata:
+  name: martin-kubernetes
+  namespace: default
+spec:
+  providerConfigRef: dev
+  volume:
+    pvcName: martin-kubernetes-root
+    namespace: default
+    storageClassName: longhorn-image-m5bh6
+    storage: '40Gi'
+    accessModes:
+    - ReadWriteMany
+    volumeMode: Block
+    annotations:
+      harvesterhci.io/imageId: default/image-m5bh6
+  cloudInit:
+    vmName: martin-kubernetes
+    namespace: default
+    hostname: martin
+    domain: stuttgart-things.local
+    timezone: Europe/Berlin
+    packages:
+    - curl
+    packageUpdate: true
+    packageUpgrade: false
+    sshPasswordAuth: false
+    disableRoot: true
+  vm:
+    runStrategy: RerunOnFailure
+    evictionStrategy: LiveMigrateIfPossible
+    terminationGracePeriodSeconds: 120
+    os: ubuntu
+    machineType: q35
+    cpu:
+      cores: 4
+      sockets: 1
+      threads: 1
+    resources:
+      memory: '4Gi'
+      cpu: '4'
+    disks:
+    - name: rootdisk
+      bus: virtio
+    - name: cloudinitdisk
+      bus: virtio
+    networks:
+    - name: default
+      networkName: default/default

--- a/claims/infra/martin-kubernetes/kustomization.yaml
+++ b/claims/infra/martin-kubernetes/kustomization.yaml
@@ -1,0 +1,5 @@
+---
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - harvestervm-developer.yaml


### PR DESCRIPTION
## Claim Manifest Created via Backstage

**Template**: harvestervm-developer
**Resource Name**: martin-kubernetes
**Category**: infra

### Manifest Details
```yaml
apiVersion: resources.stuttgart-things.com/v1alpha1
kind: HarvesterVM
metadata:
  name: martin-kubernetes
  namespace: default
spec:
  providerConfigRef: dev
  volume:
    pvcName: martin-kubernetes-root
    namespace: default
    storageClassName: longhorn-image-m5bh6
    storage: '40Gi'
    accessModes:
    - ReadWriteMany
    volumeMode: Block
    annotations:
      harvesterhci.io/imageId: default/image-m5bh6
  cloudInit:
    vmName: martin-kubernetes
    namespace: default
    hostname: martin
    domain: stuttgart-things.local
    timezone: Europe/Berlin
    packages:
    - curl
    packageUpdate: true
    packageUpgrade: false
    sshPasswordAuth: false
    disableRoot: true
  vm:
    runStrategy: RerunOnFailure
    evictionStrategy: LiveMigrateIfPossible
    terminationGracePeriodSeconds: 120
    os: ubuntu
    machineType: q35
    cpu:
      cores: 4
      sockets: 1
      threads: 1
    resources:
      memory: '4Gi'
      cpu: '4'
    disks:
    - name: rootdisk
      bus: virtio
    - name: cloudinitdisk
      bus: virtio
    networks:
    - name: default
      networkName: default/default

```

Created automatically via Backstage Claim Machinery integration.
