### PR TITLE
feat: add claims/registry.yaml as source of truth

### DIFF
--- a/claims/registry.yaml
+++ b/claims/registry.yaml
@@ -1,0 +1,44 @@
+---
+apiVersion: claim-registry.io/v1alpha1
+kind: ClaimRegistry
+claims:
+  - name: app-pvc
+    template: volumeclaim
+    category: infra
+    namespace: default
+    createdAt: "2026-02-04T19:43:28Z"
+    createdBy: patrick
+    source: backstage
+    repository: stuttgart-things/harvester
+    path: claims/infra/app-pvc
+    status: active
+  - name: abrechnungen
+    template: volumeclaim
+    category: other-resources
+    namespace: default
+    createdAt: "2026-02-05T17:45:56Z"
+    createdBy: patrick
+    source: backstage
+    repository: stuttgart-things/harvester
+    path: claims/other-resources/abrechnungen
+    status: active
+  - name: hacky
+    template: volumeclaim
+    category: cli
+    namespace: default
+    createdAt: "2026-02-05T10:58:33Z"
+    createdBy: patrick
+    source: cli
+    repository: stuttgart-things/harvester
+    path: claims/cli/hacky.yaml
+    status: active
+  - name: harvestervm-developer-martin
+    template: harvestervm
+    category: cli
+    namespace: default
+    createdAt: "2026-02-05T17:57:18Z"
+    createdBy: patrick
+    source: cli
+    repository: stuttgart-things/harvester
+    path: claims/cli/harvestervm-developer-martin.yaml
+    status: active

--- a/docs/architecture/claim-registry.md
+++ b/docs/architecture/claim-registry.md
@@ -33,21 +33,21 @@ claims:
     template: volumeclaim
     category: infra
     namespace: default
-    createdAt: "2025-06-15T10:00:00Z"
+    createdAt: "2026-02-04T19:43:28Z"
     createdBy: patrick
     source: backstage
     repository: stuttgart-things/harvester
     path: claims/infra/app-pvc
     status: active
-  - name: my-postgres
-    template: postgresql
-    category: apps
-    namespace: production
-    createdAt: "2025-07-01T14:30:00Z"
-    createdBy: claims-cli
-    source: cli
+  - name: abrechnungen
+    template: volumeclaim
+    category: other-resources
+    namespace: default
+    createdAt: "2026-02-05T17:45:56Z"
+    createdBy: patrick
+    source: backstage
     repository: stuttgart-things/harvester
-    path: claims/apps/my-postgres
+    path: claims/other-resources/abrechnungen
     status: active
 ```
 
@@ -57,7 +57,7 @@ claims:
 |-------|----------|-------------|
 | `name` | yes | Unique claim name (matches directory name) |
 | `template` | yes | Claim template used (e.g., `volumeclaim`, `postgresql`) |
-| `category` | yes | Category directory (`infra`, `apps`, `other-resources`) |
+| `category` | yes | Category directory (`infra`, `apps`, `other-resources`, `cli`) |
 | `namespace` | no | Kubernetes namespace for the claim |
 | `createdAt` | yes | ISO 8601 timestamp of creation |
 | `createdBy` | yes | User or service that created the claim |


### PR DESCRIPTION
## Summary

- Add `claims/registry.yaml` as centralized source of truth for all managed claims
- Update documentation with real claim examples and add `cli` category

Implements Phase 1a from #31.

## Changes

- **New file**: `claims/registry.yaml` with entries for all 4 existing claims:
  - `app-pvc` (volumeclaim, infra)
  - `abrechnungen` (volumeclaim, other-resources)
  - `hacky` (volumeclaim, cli)
  - `harvestervm-developer-martin` (harvestervm, cli)
- **Updated**: `docs/architecture/claim-registry.md` with real examples and `cli` category

## Test plan

- [ ] Verify registry.yaml schema matches documentation
- [ ] Verify all existing claims are listed in registry

🤖 Generated with [Claude Code](https://claude.com/claude-code)