### PR TITLE
Create 2 resource claim(s) - volumeclaim, demo-project

### DIFF
--- a/claims/infra/demo-project/catalog-info.yaml
+++ b/claims/infra/demo-project/catalog-info.yaml
@@ -1,0 +1,20 @@
+---
+apiVersion: backstage.io/v1alpha1
+kind: Component
+metadata:
+  name: demo-project
+  description: Crossplane claim (harborproject) - demo-project
+  annotations:
+    github.com/project-slug: stuttgart-things/harvester
+    backstage.io/source-location: url:https://github.com/stuttgart-things/harvester/tree/main/claims/infra/demo-project
+    claim-machinery/template: harborproject
+    claim-machinery/category: infra
+  tags:
+    - crossplane
+    - claim
+    - harborproject
+    - infra
+spec:
+  type: crossplane-claim
+  lifecycle: production
+  owner: platform-team

--- a/claims/infra/demo-project/harborproject.yaml
+++ b/claims/infra/demo-project/harborproject.yaml
@@ -1,0 +1,10 @@
+apiVersion: resources.stuttgart-things.com/v1alpha1
+kind: HarborProject
+metadata:
+  name: demo-project
+spec:
+  harborURL: https://harbor.idp.kubermatic.sva.dev
+  projectName: demo-project1
+  storageQuota: -1
+  providerConfigRef: default
+  harborInsecure: false

--- a/claims/infra/demo-project/kustomization.yaml
+++ b/claims/infra/demo-project/kustomization.yaml
@@ -1,8 +1,5 @@
+---
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:
-  - test123
-  - movies
-  - demo1
-  - volumeclaim
-  - demo-project
+  - harborproject.yaml

--- a/claims/infra/volumeclaim/catalog-info.yaml
+++ b/claims/infra/volumeclaim/catalog-info.yaml
@@ -1,0 +1,20 @@
+---
+apiVersion: backstage.io/v1alpha1
+kind: Component
+metadata:
+  name: volumeclaim
+  description: Crossplane claim (volumeclaim) - volumeclaim
+  annotations:
+    github.com/project-slug: stuttgart-things/harvester
+    backstage.io/source-location: url:https://github.com/stuttgart-things/harvester/tree/main/claims/infra/volumeclaim
+    claim-machinery/template: volumeclaim
+    claim-machinery/category: infra
+  tags:
+    - crossplane
+    - claim
+    - volumeclaim
+    - infra
+spec:
+  type: crossplane-claim
+  lifecycle: production
+  owner: platform-team

--- a/claims/infra/volumeclaim/kustomization.yaml
+++ b/claims/infra/volumeclaim/kustomization.yaml
@@ -1,8 +1,5 @@
+---
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:
-  - test123
-  - movies
-  - demo1
-  - volumeclaim
-  - demo-project
+  - volumeclaim.yaml

--- a/claims/infra/volumeclaim/volumeclaim.yaml
+++ b/claims/infra/volumeclaim/volumeclaim.yaml
@@ -1,0 +1,16 @@
+apiVersion: resources.stuttgart-things.com/v1alpha1
+kind: VolumeClaim
+metadata:
+  name: app-data
+  namespace: default
+spec:
+  accessModes:
+  - ReadWriteOnce
+  annotations:
+    description: A simple persistent volume claim for application data
+  namespace: default
+  providerConfigRef: harvester
+  pvcName: app-data
+  storage: '20Gi'
+  storageClassName: harvester-longhorn
+  volumeMode: Filesystem


### PR DESCRIPTION
## Resource Claims via Backstage

**Category**: infra
**Repository**: stuttgart-things/harvester
**Claims**: 2

### Claims Created
- **volumeclaim** (template: `volumeclaim`)
- **demo-project** (template: `harborproject`)

### Files Added
- `claims/infra/volumeclaim/volumeclaim.yaml`
- `claims/infra/volumeclaim/kustomization.yaml`
- `claims/infra/volumeclaim/catalog-info.yaml`
- `claims/infra/demo-project/harborproject.yaml`
- `claims/infra/demo-project/kustomization.yaml`
- `claims/infra/demo-project/catalog-info.yaml`
- Updated `claims/infra/kustomization.yaml`

Created automatically via Backstage Claim Machinery integration.