### PR TITLE
Create 2 resource claim(s) - volumeclaim, demo-project

### DIFF
--- a/claims/apps/demo-project.yaml
+++ b/claims/apps/demo-project.yaml
@@ -1,0 +1,10 @@
+apiVersion: resources.stuttgart-things.com/v1alpha1
+kind: HarborProject
+metadata:
+  name: demo-project
+spec:
+  harborURL: https://harbor.idp.kubermatic.sva.dev
+  projectName: demo-project1
+  storageQuota: -1
+  providerConfigRef: default
+  harborInsecure: false

--- a/claims/apps/volumeclaim.yaml
+++ b/claims/apps/volumeclaim.yaml
@@ -1,0 +1,16 @@
+apiVersion: resources.stuttgart-things.com/v1alpha1
+kind: VolumeClaim
+metadata:
+  name: app-data
+  namespace: default
+spec:
+  accessModes:
+  - ReadWriteOnce
+  annotations:
+    description: A simple persistent volume claim for application data
+  namespace: default
+  providerConfigRef: harvester
+  pvcName: app-data
+  storage: '20Gi'
+  storageClassName: harvester-longhorn
+  volumeMode: Filesystem


### PR DESCRIPTION
## Resource Claims via Backstage

**Category**: apps
**Repository**: stuttgart-things/harvester
**Claims**: 2
**Mode**: manifest-only

### Claims Created
- **volumeclaim** (template: `volumeclaim`)
- **demo-project** (template: `harborproject`)

### Files
- `claims/apps/volumeclaim.yaml`
- `claims/apps/demo-project.yaml`

Created automatically via Backstage Claim Machinery integration.