### PR TITLE
feat(infra): add cluster-specific harvester.sthings.lab certificate

### DIFF
--- a/clusters/infra/harvester-certificate.yaml
+++ b/clusters/infra/harvester-certificate.yaml
@@ -1,0 +1,25 @@
+---
+# Cluster-specific single-host certificate for the Harvester UI/API endpoint.
+# Lives here (not in the generic stuttgart-things/flux cert-manager definition)
+# because the hostname is specific to this cluster.
+#
+# Issued by the vault-pki ClusterIssuer. On first reconcile Flux adopts the
+# pre-existing, hand-managed harvester-tls secret via server-side-apply
+# (no re-issue, no owner conflict) as long as only this manifest manages it.
+apiVersion: cert-manager.io/v1
+kind: Certificate
+metadata:
+  name: harvester-tls
+  namespace: default
+spec:
+  commonName: harvester.sthings.lab
+  dnsNames:
+    - harvester.sthings.lab
+  secretName: harvester-tls # pragma: allowlist secret
+  issuerRef:
+    name: vault-pki
+    kind: ClusterIssuer
+  duration: 2160h # 90 days
+  renewBefore: 360h # renew 15 days before expiry
+  privateKey:
+    rotationPolicy: Always


### PR DESCRIPTION
## What

Adds a raw cert-manager `Certificate` manifest for the Harvester host endpoint at `clusters/infra/harvester-certificate.yaml`.

## Why here (and not in stuttgart-things/flux)

The `stuttgart-things/flux` repo holds the **generic, cluster-agnostic** cert-manager install/component definitions. A `Certificate` with a hard-coded `harvester.sthings.lab` hostname is **cluster-specific** and belongs in this repo's `clusters/infra` path.

## How it's applied

`clusters/infra` is the `FluxInstance` sync path (`config.yaml`). There is no `kustomization.yaml` with an explicit `resources:` list — Flux applies all manifests in the path directly (the SOPS-encrypted `secrets.yaml` / `clusterbook-ddwrt-secret.yaml` confirm raw manifests work here). So dropping the file in is sufficient; no resources-list edit needed.

## Adoption behavior

The spec matches the live `harvester-tls` (vault-pki `ClusterIssuer`, `duration: 2160h`, `renewBefore: 360h`). On first reconcile Flux adopts the pre-existing, hand-managed `harvester-tls` secret via server-side-apply — **no re-issue, no owner conflict** as long as only this manifest manages it.

`privateKey.rotationPolicy: Always` is set explicitly; it's already the default in cert-manager ≥ 1.18 (cluster runs v1.19.1), so it silences the rotation-policy warning without triggering a reissue.

## Notes / out of scope

- ⏰ The vault-pki signing token expires **2026-07-03** (720h TTL). Migrating the `vault-pki` issuer to Kubernetes auth would stop this recurring every ~30 days — that config lives in the `vault-base-setup` module in `stuttgart-things/flux`, so it's tracked separately.

https://claude.ai/code/session_01JPcMFz4gL5BJ3Xhusaegqr

---
_Generated by [Claude Code](https://claude.ai/code/session_01JPcMFz4gL5BJ3Xhusaegqr)_