### PR TITLE
ci(packer): make PR-build upload to Harvester toggleable

### DIFF
--- a/.github/workflows/packer-pr-build.yml
+++ b/.github/workflows/packer-pr-build.yml
@@ -76,6 +76,9 @@ jobs:
     environment: harvester
     env:
       PACKER_LOG: 0
+      # Set repo/env variable UPLOAD_TO_HARVESTER=false while Harvester is down.
+      # Unset/true keeps the normal upload + auto-merge behaviour.
+      UPLOAD_TO_HARVESTER: ${{ vars.UPLOAD_TO_HARVESTER != 'false' }}
     strategy:
       matrix:
         include: ${{ fromJson(needs.detect-targets.outputs.targets) }}
@@ -88,7 +91,7 @@ jobs:
         run: |
           echo "Packer dir            : ${{ matrix.packer_dir }}"
           echo "Image name            : ${{ matrix.image_name }}"
-          echo "Upload to Harvester   : true"
+          echo "Upload to Harvester   : ${{ env.UPLOAD_TO_HARVESTER }}"
           echo "Trigger               : ${{ github.event_name }}"
           echo "PR number             : ${{ github.event.pull_request.number || 'N/A' }}"
 
@@ -100,13 +103,13 @@ jobs:
         working-directory: ${{ matrix.packer_dir }}
         env:
           PKR_VAR_image_name: ${{ matrix.image_name }}
-          PKR_VAR_upload_to_harvester: "true"
+          PKR_VAR_upload_to_harvester: ${{ env.UPLOAD_TO_HARVESTER }}
           PKR_VAR_harvester_vip: ${{ secrets.HARVESTER_VIP }}
           PKR_VAR_harvester_password: ${{ secrets.HARVESTER_PASSWORD }}
         run: packer build .
 
       - name: Auto-merge PR
-        if: success() && github.event_name == 'pull_request'
+        if: success() && github.event_name == 'pull_request' && env.UPLOAD_TO_HARVESTER == 'true'
         env:
           GH_TOKEN: ${{ github.token }}
         run: |


### PR DESCRIPTION
## Why

The PR-triggered `packer-build-pr` job hard-codes the Harvester upload to `"true"`. Whenever Harvester is unreachable (e.g. an outage), every PR build fails red — even though the Packer config itself is fine. The `workflow_dispatch` path already has an `upload_to_harvester` toggle; the PR path did not.

## What

Drive the PR job's upload via the repo/environment variable `UPLOAD_TO_HARVESTER` instead of a hard-coded literal. **Default behaviour is unchanged** (unset/`true` → upload + auto-merge as before).

- `UPLOAD_TO_HARVESTER: ${{ vars.UPLOAD_TO_HARVESTER != 'false' }}` at job level
- `PKR_VAR_upload_to_harvester` and the build-parameter echo now read this env var
- Auto-merge is additionally gated on `env.UPLOAD_TO_HARVESTER == 'true'`, so PRs are **not** auto-merged when uploads are paused

Minimal, backwards-compatible, scoped to the PR job only. The `workflow_dispatch` and `detect-targets` jobs are untouched.

## Operating during a Harvester outage

```bash
# Harvester down → pause uploads + auto-merge (builds stay green & config-validating)
gh variable set UPLOAD_TO_HARVESTER --repo stuttgart-things/harvester --body false

# Harvester back up → restore normal behaviour
gh variable delete UPLOAD_TO_HARVESTER --repo stuttgart-things/harvester
```

With the toggle off, Packer still runs `init`/`build` (validating the config) but skips the upload, and the PR is left for manual review/merge.

## Notes

- The path-extension to `*-staging`/`*-prod` packer dirs discussed during planning is **not** included here: those directories do not yet exist in the repo, so there is nothing to add to `on.pull_request.paths`. That belongs with the admin-template coordination work once the hardened dirs land.

https://claude.ai/code/session_01D7P3PFj3STzLF64FyiGWxx

---
_Generated by [Claude Code](https://claude.ai/code/session_01D7P3PFj3STzLF64FyiGWxx)_