### PR TITLE
feat(platform): add argo-cd

### DIFF
--- a/clusters/platform/apps/argo-cd-httproute.yaml
+++ b/clusters/platform/apps/argo-cd-httproute.yaml
@@ -1,0 +1,25 @@
+---
+apiVersion: kustomize.toolkit.fluxcd.io/v1
+kind: Kustomization
+metadata:
+  name: argo-cd-httproute
+  namespace: flux-system
+spec:
+  interval: 1h
+  retryInterval: 1m
+  timeout: 5m
+  sourceRef:
+    kind: GitRepository
+    name: flux-apps
+  path: ./cicd/argo-cd/components/httproute
+  prune: true
+  wait: true
+  dependsOn:
+    - name: argo-cd
+  postBuild:
+    substitute:
+      ARGO_CD_NAMESPACE: argocd
+      ARGO_CD_HOSTNAME: argocd
+      ARGO_CD_DOMAIN: platform.sthings.lab
+      GATEWAY_NAME: platform-sthings-gateway
+      GATEWAY_NAMESPACE: default

--- a/clusters/platform/apps/argo-cd.yaml
+++ b/clusters/platform/apps/argo-cd.yaml
@@ -24,7 +24,7 @@ spec:
       INGRESS_SECRET_NAME: argocd-server-tls # pragma: allowlist secret
       ISSUER_NAME: vault-pki
       ISSUER_KIND: ClusterIssuer
-      ARGO_CD_PASSWORD_MTIME: "2026-03-23T02:00:00UTC"
+      ARGO_CD_PASSWORD_MTIME: "2026-03-23T02:00:00UTC" # pragma: allowlist secret
       AVP_TRUST_BUNDLE_CONFIGMAP: cluster-trust-bundle
       AVP_TRUST_BUNDLE_KEY: trust-bundle.pem
       AVP_SSL_CERT_DIR: /etc/ssl/custom

--- a/clusters/platform/apps/argo-cd.yaml
+++ b/clusters/platform/apps/argo-cd.yaml
@@ -1,0 +1,38 @@
+---
+apiVersion: kustomize.toolkit.fluxcd.io/v1
+kind: Kustomization
+metadata:
+  name: argo-cd
+  namespace: flux-system
+spec:
+  interval: 1h
+  retryInterval: 1m
+  timeout: 5m
+  sourceRef:
+    kind: GitRepository
+    name: flux-apps
+  path: ./cicd/argo-cd
+  prune: true
+  wait: true
+  postBuild:
+    substitute:
+      ARGO_CD_VERSION: "9.4.15"
+      ARGO_CD_NAMESPACE: argocd
+      ARGO_CD_INGRESS_ENABLED: "false"
+      INGRESS_HOSTNAME: argocd
+      INGRESS_DOMAIN: platform.sthings.lab
+      INGRESS_SECRET_NAME: argocd-server-tls # pragma: allowlist secret
+      ISSUER_NAME: vault-pki
+      ISSUER_KIND: ClusterIssuer
+      ARGO_CD_PASSWORD_MTIME: "2026-03-23T02:00:00UTC"
+      AVP_TRUST_BUNDLE_CONFIGMAP: cluster-trust-bundle
+      AVP_TRUST_BUNDLE_KEY: trust-bundle.pem
+      AVP_SSL_CERT_DIR: /etc/ssl/custom
+    substituteFrom:
+      - kind: Secret
+        name: argocd-secrets
+  healthChecks:
+    - apiVersion: helm.toolkit.fluxcd.io/v2
+      kind: HelmRelease
+      name: argocd-deployment
+      namespace: argocd


### PR DESCRIPTION
## Add Argo CD to the platform cluster

Adds Flux `Kustomization` resources under `clusters/platform/apps/` to deploy **Argo CD** on the `platform.sthings.lab` cluster, modelled on the example in [`stuttgart-things/clusters/labul/vsphere/platform-sthings`](https://github.com/stuttgart-things/stuttgart-things/tree/main/clusters/labul/vsphere/platform-sthings).

### Files
- `clusters/platform/apps/argo-cd.yaml` — points at `./cicd/argo-cd` in the `flux-apps` GitRepository (`stuttgart-things/flux`).
- `clusters/platform/apps/argo-cd-httproute.yaml` — Gateway API `HTTPRoute` (depends on `argo-cd`).

### Platform adaptations
| Setting | Value |
|---|---|
| Domain | `platform.sthings.lab` |
| Gateway | `platform-sthings-gateway` / `default` |
| ClusterIssuer | `vault-pki` |
| Source | `flux-apps` |

### Required before reconcile
- The `flux-apps` GitRepository must exist in `flux-system` (bootstrapped per the platform `README.md`).
- A SOPS-encrypted **`argocd-secrets`** Secret providing `ARGO_CD_SERVER_ADMIN_PASSWORD` (admin password) must be added — not included here as it contains credentials.

Part of: add argocd, rancher, minio and harbor to the platform cluster.

https://claude.ai/code/session_014x4LVcwkrq73KDcKWLb8Wa

---
_Generated by [Claude Code](https://claude.ai/code/session_014x4LVcwkrq73KDcKWLb8Wa)_