### PR TITLE
feat(platform): add rancher

### DIFF
--- a/clusters/platform/apps/rancher-secrets.enc.yaml
+++ b/clusters/platform/apps/rancher-secrets.enc.yaml
@@ -1,0 +1,23 @@
+apiVersion: ENC[AES256_GCM,data:Pp4=,iv:cZMDD5su3Qdt/fZjcdsrPET1O9zvAdAI21PpL5Ru2Oo=,tag:tU7ZIdsc6feYNri2rdoAEQ==,type:str]
+kind: ENC[AES256_GCM,data:8K2rmRBm,iv:E7KXyiIgaP5c66I9y/jfRbhVR84L0GKjEQJrI9HdGa8=,tag:z6tVcpctLYZOIdX+Y+k//A==,type:str]
+metadata:
+    name: ENC[AES256_GCM,data:LEsxwxWHfVMCpb/quB1H,iv:5mutNESsAlG1BYJmKZoeqWubcLEtxqqFtEASCT5Mjrk=,tag:PsNjzdXBQhssa9nt6/Yb+A==,type:str]
+    namespace: ENC[AES256_GCM,data:J6MaMVpifbVDSPg=,iv:MBvGGau4BiRI4s05cA0v8IdtKDhTiJpqbmYVd96faHQ=,tag:KWRdjMz+t4oTghwGDQukxw==,type:str]
+type: ENC[AES256_GCM,data:28W/z19R,iv:GWIayR35uI8YrGEl8Em+DozmgVUBmsrL45A3bQk6l1k=,tag:ACAX4DJh6bfdz7XXrENejQ==,type:str]
+stringData:
+    BOOTSTRAP_PASSWORD: ENC[AES256_GCM,data:IR8hQjGGV0S/OlqSu47hnPs=,iv:cuQ+f9OPxUAjkLZDE9o9xBS0vAaOEpR3Eh8ot0ofOdo=,tag:vPmHNQpHO6dF5JwCnz0vUA==,type:str]
+sops:
+    age:
+        - recipient: age19vgzvmpt9tdlcsu8rzaacj397yz8gguz38nsmuy6eeelt5vjsyms542xtm
+          enc: |
+            -----BEGIN AGE ENCRYPTED FILE-----
+            YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSB5RmtFTHQ3UmdzRUVPOW93
+            UnFuTFZnODNQTWhqU0Ziczk1ZG9tUng2bkI4Cnp6RGlkZ3F5K0lTTkFXTk9XU0ZF
+            SGtiMkVlUkRwRWVWbEtQWGpmMUQ4QTAKLS0tIG1SakhTamxzWFNDQ0d1Y2dNWnBX
+            UWNsZWliR1ZlSXNnUnVBQnhPWHV4dmMKLq0iI9QX4F6+6zzI/OL4X/ktjKGjTGMS
+            Ie9sUZPJuogsb2OvCiLMiicsmc0FxyFBw1GfayKY+SEuOHjDOoph7g==
+            -----END AGE ENCRYPTED FILE-----
+    lastmodified: "2026-06-01T19:56:52Z"
+    mac: ENC[AES256_GCM,data:MVqFdaOu69w2mFxtqxkmcNPhTDOyRZqbXegnowzXMxRyuS+Efkbec12APE+S57aTv4bgOpXDShmgtojAHFQgbrVzLBqyXFiAEbw7GhdOA+CWuyRkdb9McmYVeIHZrSWCM0wQOFvj6vIE8fU+D9O9KML6wQ+mfZJjdEgiE/5i33w=,iv:Yd/ZRlNc0kGF2wbUNLkcIm7ED4dlseRun+TE4H4hM7k=,tag:9uNR6Cm0uGZvLUKXh62uzw==,type:str]
+    unencrypted_suffix: _unencrypted
+    version: 3.12.1

--- a/clusters/platform/apps/rancher.yaml
+++ b/clusters/platform/apps/rancher.yaml
@@ -1,0 +1,35 @@
+---
+apiVersion: kustomize.toolkit.fluxcd.io/v1
+kind: Kustomization
+metadata:
+  labels:
+    app.kubernetes.io/managed-by: flux
+    kustomization.stuttgart-things.com/type: app
+  name: rancher
+  namespace: flux-system
+spec:
+  force: false
+  interval: '1h'
+  path: './apps/rancher'
+  postBuild:
+    substitute:
+      CLUSTER_ISSUER: vault-pki
+      GATEWAY_NAME: platform-sthings-gateway
+      GATEWAY_NAMESPACE: default
+      INGRESS_DOMAIN: platform.sthings.lab
+      INGRESS_HOSTNAME: rancher
+      RANCHER_NAMESPACE: cattle-system
+      RANCHER_REPLICAS: '1'
+      RANCHER_VERSION: 2.14.2
+    substituteFrom:
+    - kind: Secret
+      name: rancher-secrets
+      optional: false
+  prune: true
+  retryInterval: '1m'
+  sourceRef:
+    kind: GitRepository
+    name: flux-apps
+  suspend: false
+  timeout: '10m'
+  wait: false


### PR DESCRIPTION
## Add Rancher to the platform cluster

Adds a Flux `Kustomization` under `clusters/platform/apps/` to deploy **Rancher** on the `platform.sthings.lab` cluster, modelled on the example in [`stuttgart-things/clusters/labul/vsphere/platform-sthings`](https://github.com/stuttgart-things/stuttgart-things/tree/main/clusters/labul/vsphere/platform-sthings).

### Files
- `clusters/platform/apps/rancher.yaml` — points at `./apps/rancher` in the `flux-apps` GitRepository (`stuttgart-things/flux`). The `HTTPRoute` is bundled inside that app kustomization, so no separate httproute file is needed.
- `clusters/platform/apps/rancher-secrets.enc.yaml` — SOPS-encrypted `rancher-secrets` Secret (`BOOTSTRAP_PASSWORD`), copied verbatim from the example. Encrypted to the same age recipient as this cluster's `sops-age` key, so it decrypts in-cluster.

### Platform adaptations
| Setting | Value |
|---|---|
| Domain | `platform.sthings.lab` |
| Gateway | `platform-sthings-gateway` / `default` |
| ClusterIssuer | `vault-pki` |
| Namespace | `cattle-system` |
| Version | `2.14.2` |
| Source | `flux-apps` |

### Prerequisite
- The `flux-apps` GitRepository must exist in `flux-system` (bootstrapped per the platform `README.md`).

Part of: add argocd, rancher, minio and harbor to the platform cluster.

https://claude.ai/code/session_014x4LVcwkrq73KDcKWLb8Wa