### PR TITLE
feat(platform): add minio

### DIFF
--- a/clusters/platform/apps/minio-httproute.yaml
+++ b/clusters/platform/apps/minio-httproute.yaml
@@ -1,0 +1,31 @@
+---
+apiVersion: kustomize.toolkit.fluxcd.io/v1
+kind: Kustomization
+metadata:
+  labels:
+    app.kubernetes.io/managed-by: flux
+    kustomization.stuttgart-things.com/type: app
+  name: minio-httproute
+  namespace: flux-system
+spec:
+  dependsOn:
+  - name: minio
+  force: false
+  interval: '1h'
+  path: './apps/minio/components/httproute'
+  postBuild:
+    substitute:
+      MINIO_NAMESPACE: minio
+      INGRESS_HOSTNAME_CONSOLE: artifacts-console
+      INGRESS_HOSTNAME_API: artifacts
+      INGRESS_DOMAIN: platform.sthings.lab
+      GATEWAY_NAME: platform-sthings-gateway
+      GATEWAY_NAMESPACE: default
+  prune: true
+  retryInterval: '1m'
+  sourceRef:
+    kind: GitRepository
+    name: flux-apps
+  suspend: false
+  timeout: '5m'
+  wait: true

--- a/clusters/platform/apps/minio-secrets.enc.yaml
+++ b/clusters/platform/apps/minio-secrets.enc.yaml
@@ -1,0 +1,29 @@
+apiVersion: ENC[AES256_GCM,data:rE0=,iv:1wtl4k/F1bHMCTXTodr9TFQkqaney8EBn6h9SvPZK5A=,tag:k81G0nkklZWXCnuXmUm1fg==,type:str]
+kind: ENC[AES256_GCM,data:3R/q7dEk,iv:W42WPguXyMWmHpZBmgkxq7ZOmbb8bda0b7IDGOVLYIU=,tag:iFtwnTPOQtjUiOYgGhAJJQ==,type:str]
+metadata:
+    name: ENC[AES256_GCM,data:3FAKqd/DgUfuqn6mDg==,iv:F+kQ5bb4Hga6U04kz+sV+bDHiEs0Rgi08irIzrDs6hc=,tag:xjLz9ZizmB3lJKuXiSR2WQ==,type:str]
+    namespace: ENC[AES256_GCM,data:99jxdhoGr4uD+jg=,iv:ejtd33Aj1jrnnSfjQ/gkjLgHxueEIhF1b5EQ1i8Zlfs=,tag:29sNNblhl+QxNlssRGSvDA==,type:str]
+type: ENC[AES256_GCM,data:yTZdYoEE,iv:az8yyTQX+9vWgOdIZUDjKEQycz16DjWgY8rZv+P1S2Q=,tag:AGsOvTmDVzRzomgVX3qLLQ==,type:str]
+stringData:
+    MINIO_ADMIN_USER: ENC[AES256_GCM,data:r2zx6NMmJA==,iv:VQLZKRvolMYjBw/ScxEnxUhlQGSPVbnnfbToHg4AjWE=,tag:FUlJYy2axVTYcdrFZcS13Q==,type:str]
+    MINIO_ADMIN_PASSWORD: ENC[AES256_GCM,data:aB9zBXgBOO4=,iv:/5NK9IKURYRCwNJLSSjNUJp3LgRdWNje0vkQ5ofu2Ag=,tag:4Ysv6up5lmJqWNveO6Y9cQ==,type:str]
+sops:
+    kms: []
+    gcp_kms: []
+    azure_kv: []
+    hc_vault: []
+    age:
+        - recipient: age19vgzvmpt9tdlcsu8rzaacj397yz8gguz38nsmuy6eeelt5vjsyms542xtm
+          enc: |
+            -----BEGIN AGE ENCRYPTED FILE-----
+            YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSBjY3hVUUZlSHRaREllbzk4
+            OVFWL3ltRWJuUjlkdS9GZlBycEZSSHpiZnlRCnpEc3ZrWHhKU2hBUEh6aldlTktu
+            UTJySVVLanBDKzZJSWNQUVphV0tyWHcKLS0tIG9yNzJzcWtsNGp4YkhXSExKREVX
+            ZWZ4TzlXY2ZHV0JiWkpzMmVKUnh5OVkKmmjyflgzAKS0GnS9ycbP3i4swUVM5Khf
+            zC1tOaGHGZsxiRy9rgzuy3pCn4ht/hInGjgNohoxqySnOlpxKHm1+g==
+            -----END AGE ENCRYPTED FILE-----
+    lastmodified: "2026-06-05T07:18:59Z"
+    mac: ENC[AES256_GCM,data:vX9iyt0pXC2ewT1LVA4mevlPjEhye8jkx/6gQMnbvphBPqHltR6kiJ2bKXZJnz+NVTMMev733HMWZHukZtMNcdDlyBIbrIRzES0VHgfwhqPj8x7HfNeDjUKbSf06766RUeRSp7bvQfWMbVdXFpgnbRVwrIRzruFV6zU0AXDqqSQ=,iv:LPEborcqHGED9uAOt0tC8XRlt/npJH1hfS5vtsfxaH4=,tag:9KZ5GC2LvFcICg93mdYlOg==,type:str]
+    pgp: []
+    unencrypted_suffix: _unencrypted
+    version: 3.9.4

--- a/clusters/platform/apps/minio.yaml
+++ b/clusters/platform/apps/minio.yaml
@@ -1,0 +1,36 @@
+---
+apiVersion: kustomize.toolkit.fluxcd.io/v1
+kind: Kustomization
+metadata:
+  labels:
+    app.kubernetes.io/managed-by: flux
+    kustomization.stuttgart-things.com/type: app
+  name: minio
+  namespace: flux-system
+spec:
+  force: false
+  interval: '1h'
+  path: './apps/minio'
+  postBuild:
+    substitute:
+      MINIO_NAMESPACE: minio
+      MINIO_VERSION: '16.0.10'
+      MINIO_INGRESS_ENABLED: 'false'
+      CLUSTER_ISSUER: vault-pki
+      INGRESS_HOSTNAME_CONSOLE: artifacts-console
+      INGRESS_HOSTNAME_API: artifacts
+      INGRESS_DOMAIN: platform.sthings.lab
+      STORAGE_CLASS: nfs4-csi
+      MINIO_STORAGE_SIZE: '10Gi'
+    substituteFrom:
+    - kind: Secret
+      name: minio-secrets
+      optional: false
+  prune: true
+  retryInterval: '1m'
+  sourceRef:
+    kind: GitRepository
+    name: flux-apps
+  suspend: false
+  timeout: '5m'
+  wait: true


### PR DESCRIPTION
## Add MinIO to the platform cluster

Adds Flux `Kustomization` resources under `clusters/platform/apps/` to deploy **MinIO** on the `platform.sthings.lab` cluster, modelled on the example in [`stuttgart-things/clusters/labul/vsphere/platform-sthings`](https://github.com/stuttgart-things/stuttgart-things/tree/main/clusters/labul/vsphere/platform-sthings).

### Files
- `clusters/platform/apps/minio.yaml` — points at `./apps/minio` in the `flux-apps` GitRepository (`stuttgart-things/flux`).
- `clusters/platform/apps/minio-httproute.yaml` — Gateway API `HTTPRoute` for the API + console (depends on `minio`).

### Platform adaptations
| Setting | Value |
|---|---|
| Domain | `platform.sthings.lab` (API `artifacts`, console `artifacts-console`) |
| Gateway | `platform-sthings-gateway` / `default` |
| ClusterIssuer | `vault-pki` |
| Storage class | `nfs4-csi` (platform uses nfs-csi; example used `openebs-hostpath`) |
| Source | `flux-apps` |

### Required before reconcile
- The `flux-apps` GitRepository must exist in `flux-system` (bootstrapped per the platform `README.md`).
- A SOPS-encrypted **`minio-secrets`** Secret providing `MINIO_ADMIN_USER` / `MINIO_ADMIN_PASSWORD` must be added — not included here as it contains credentials.

Part of: add argocd, rancher, minio and harbor to the platform cluster.

https://claude.ai/code/session_014x4LVcwkrq73KDcKWLb8Wa

---
_Generated by [Claude Code](https://claude.ai/code/session_014x4LVcwkrq73KDcKWLb8Wa)_