### PR TITLE
feat(platform): add harbor

### DIFF
--- a/clusters/platform/apps/harbor-httproute.yaml
+++ b/clusters/platform/apps/harbor-httproute.yaml
@@ -1,0 +1,30 @@
+---
+apiVersion: kustomize.toolkit.fluxcd.io/v1
+kind: Kustomization
+metadata:
+  labels:
+    app.kubernetes.io/managed-by: flux
+    kustomization.stuttgart-things.com/type: app
+  name: harbor-httproute
+  namespace: flux-system
+spec:
+  dependsOn:
+  - name: harbor
+  force: false
+  interval: '1h'
+  path: './apps/harbor/httproute'
+  postBuild:
+    substitute:
+      HARBOR_NAMESPACE: harbor
+      GATEWAY_NAME: platform-sthings-gateway
+      GATEWAY_NAMESPACE: default
+      HARBOR_HOSTNAME: harbor
+      HARBOR_DOMAIN: platform.sthings.lab
+  prune: true
+  retryInterval: '1m'
+  sourceRef:
+    kind: GitRepository
+    name: flux-apps
+  suspend: false
+  timeout: '5m'
+  wait: true

--- a/clusters/platform/apps/harbor-secrets.enc.yaml
+++ b/clusters/platform/apps/harbor-secrets.enc.yaml
@@ -1,0 +1,23 @@
+apiVersion: ENC[AES256_GCM,data:6L8=,iv:+8RzcTjxgRM4+K66xxd5S/7Q3CaVWG07cZohFI2SNp8=,tag:jq7bemXKfGMBeCrTbdDjQA==,type:str]
+kind: ENC[AES256_GCM,data:srrHKJlv,iv:39WUT7WPvBfPsLtgkmJEb6H6+uxbgKwsVV95u9ow8uw=,tag:eX45UFqac97GfPsALNAwUA==,type:str]
+metadata:
+    name: ENC[AES256_GCM,data:qM7II2qVmsIJquphnNo=,iv:Y6G0DDdj55R/qWWPHXTsizGzzIdap10ANfhhIbJXUU8=,tag:te5cAqEC20QzcFmZi81CAA==,type:str]
+    namespace: ENC[AES256_GCM,data:S6yyPiUO/6WTEk8=,iv:pJaIMhdHJE0bOctJb+T0v8aKDVJpKvsKlp4uOahwfE0=,tag:nlJODOpxvTHTH9aAaMZ7Cg==,type:str]
+type: ENC[AES256_GCM,data:rghy9Nqg,iv:qC8c65q27c1WMm12XoiuO7dGq8G/NPK2TnDOrJrY6SM=,tag:18HI5oJPHth4IHdgfHyf4w==,type:str]
+stringData:
+    HARBOR_ADMIN_PASSWORD: ENC[AES256_GCM,data:XmiSov399Wo=,iv:1Ogf4APs6vsul/sIGyQIdgnrFhM0wNyP2e6rPa7ICK4=,tag:FcoowkVdxTUaivFwx1Fiog==,type:str]
+sops:
+    age:
+        - recipient: age19vgzvmpt9tdlcsu8rzaacj397yz8gguz38nsmuy6eeelt5vjsyms542xtm
+          enc: |
+            -----BEGIN AGE ENCRYPTED FILE-----
+            YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSB2a2FLTlJaQWt6dmFGV1M3
+            T0IwYi91NURWZE96aERZMEk1ZVJQaW54YlE4CmUwTTRyZXZocXpKMXRXbXZnU3BT
+            eHUvc3g1cFlmbVZEQ280NTN3TnBiRmMKLS0tIHlPMnNZSXpkUUZDTHFMYnlMcm0y
+            SXExdzA0c2U1RzVkdEhsYUxQeTlzSm8K5pzNXHN8DtRdWNSpYPwOJ9cSRwnhBk2k
+            VjNANSXi10JzeamfBgDBQTtIJjDWOcgEX77lFUXIw+5ZaDKgRKRqQA==
+            -----END AGE ENCRYPTED FILE-----
+    lastmodified: "2026-03-25T19:15:23Z"
+    mac: ENC[AES256_GCM,data:2MYbv2OuhvVO1QfZeCNnZEV80uhSo5SivqBe5/zFnVFtvzkNZA4rE3L/SnMzPms2gWQDVFB7i0gE47lu8Pcc9o1A3FLED84ii0l7D4j+IcIyceDxQIwCLcinyAnI6ZBLo8CDqTbPgE0mB8TCf7/njynPocj4xqw/DEd+LTQY8fE=,iv:83lJP3WhCI+CGj+p5jbbvM1zNjtOTe90OAz76tJTxQQ=,tag:pogpokCWN2HrQ50hcDlZtA==,type:str]
+    unencrypted_suffix: _unencrypted
+    version: 3.10.2

--- a/clusters/platform/apps/harbor.yaml
+++ b/clusters/platform/apps/harbor.yaml
@@ -21,7 +21,7 @@ spec:
       INGRESS_CLASS_NAME: nginx
       ISSUER_NAME: vault-pki
       ISSUER_KIND: ClusterIssuer
-      STORAGE_CLASS: nfs4-csi
+      STORAGE_CLASS: local-path
       HARBOR_PV_SIZE_REGISTRY: 12Gi
       HARBOR_PV_SIZE_TRIVY: 5Gi
       HARBOR_PV_SIZE_JOBSERVICE: 1Gi

--- a/clusters/platform/apps/harbor.yaml
+++ b/clusters/platform/apps/harbor.yaml
@@ -1,0 +1,44 @@
+---
+apiVersion: kustomize.toolkit.fluxcd.io/v1
+kind: Kustomization
+metadata:
+  labels:
+    app.kubernetes.io/managed-by: flux
+    kustomization.stuttgart-things.com/type: app
+  name: harbor
+  namespace: flux-system
+spec:
+  force: false
+  interval: '1h'
+  path: './apps/harbor'
+  postBuild:
+    substitute:
+      HARBOR_NAMESPACE: harbor
+      HARBOR_VERSION: '27.0.3'
+      HARBOR_HOSTNAME: harbor
+      HARBOR_DOMAIN: platform.sthings.lab
+      EXPOSURE_TYPE: none
+      INGRESS_CLASS_NAME: nginx
+      ISSUER_NAME: vault-pki
+      ISSUER_KIND: ClusterIssuer
+      STORAGE_CLASS: nfs4-csi
+      HARBOR_PV_SIZE_REGISTRY: 12Gi
+      HARBOR_PV_SIZE_TRIVY: 5Gi
+      HARBOR_PV_SIZE_JOBSERVICE: 1Gi
+    substituteFrom:
+    - kind: Secret
+      name: harbor-secrets
+      optional: false
+  prune: true
+  retryInterval: '1m'
+  sourceRef:
+    kind: GitRepository
+    name: flux-apps
+  suspend: false
+  timeout: '10m'
+  wait: true
+  healthChecks:
+    - apiVersion: helm.toolkit.fluxcd.io/v2
+      kind: HelmRelease
+      name: harbor
+      namespace: harbor


### PR DESCRIPTION
## Add Harbor to the platform cluster

Adds Flux `Kustomization` resources under `clusters/platform/apps/` to deploy **Harbor** on the `platform.sthings.lab` cluster, modelled on the example in [`stuttgart-things/clusters/labul/vsphere/platform-sthings`](https://github.com/stuttgart-things/stuttgart-things/tree/main/clusters/labul/vsphere/platform-sthings).

### Files
- `clusters/platform/apps/harbor.yaml` — points at `./apps/harbor` in the `flux-apps` GitRepository (`stuttgart-things/flux`).
- `clusters/platform/apps/harbor-httproute.yaml` — Gateway API `HTTPRoute` (depends on `harbor`).
- `clusters/platform/apps/harbor-secrets.enc.yaml` — SOPS-encrypted `harbor-secrets` Secret (`HARBOR_ADMIN_PASSWORD`), copied verbatim from the example. Encrypted to the same age recipient as this cluster's `sops-age` key, so it decrypts in-cluster.

### Platform adaptations
| Setting | Value |
|---|---|
| Domain | `platform.sthings.lab` (host `harbor`) |
| Gateway | `platform-sthings-gateway` / `default` |
| ClusterIssuer | `vault-pki` |
| Storage class | `nfs4-csi` |
| Version | `27.0.3` |
| Source | `flux-apps` |

### Prerequisite
- The `flux-apps` GitRepository must exist in `flux-system` (bootstrapped per the platform `README.md`).

Part of: add argocd, rancher, minio and harbor to the platform cluster.

https://claude.ai/code/session_014x4LVcwkrq73KDcKWLb8Wa