### PR TITLE
feat: deploy backstage edge instance on platform cluster

### DIFF
--- a/clusters/platform/backstage-prereqs.yaml
+++ b/clusters/platform/backstage-prereqs.yaml
@@ -1,0 +1,33 @@
+---
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: backstage
+  labels:
+    toolkit.fluxcd.io/tenant: sthings-team
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: backstage-ca-env
+  namespace: backstage
+data:
+  NODE_EXTRA_CA_CERTS: /etc/ssl/custom/trust-bundle.pem
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: backstage-catalog-config
+  namespace: backstage
+data:
+  app-config.catalog.yaml: |
+    catalog:
+      locations:
+        - type: url
+          target: https://github.com/stuttgart-things/backstage-resources/blob/main/org/sthings-harvester/org.yaml
+          rules:
+            - allow: [User, Group]
+        - type: url
+          target: https://github.com/stuttgart-things/backstage-resources/blob/main/services/sthings-harvester/catalog-index.yaml
+          rules:
+            - allow: [Component, Location, System, API, Resource, Template]

--- a/clusters/platform/backstage-secrets.enc.yaml.example
+++ b/clusters/platform/backstage-secrets.enc.yaml.example
@@ -1,0 +1,47 @@
+# ---------------------------------------------------------------------------
+# SKELETON / TEMPLATE - NOT APPLIED BY FLUX (.example suffix is ignored by the
+# kustomize-controller, which only applies .yaml/.yml/.json files).
+#
+# This is the plaintext template for the Backstage substitution secret used by
+# clusters/platform/backstage.yaml (postBuild.substituteFrom). Fill in the real
+# values, then SOPS-encrypt it into backstage-secrets.enc.yaml so Flux can
+# decrypt and apply it on reconcile. NEVER commit the plaintext values.
+#
+#   cp backstage-secrets.enc.yaml.example /tmp/backstage-secrets.yaml
+#   # edit /tmp/backstage-secrets.yaml and fill in the REPLACE_ME values
+#   sops --encrypt \
+#     --age age19vgzvmpt9tdlcsu8rzaacj397yz8gguz38nsmuy6eeelt5vjsyms542xtm \
+#     /tmp/backstage-secrets.yaml > backstage-secrets.enc.yaml
+#   rm /tmp/backstage-secrets.yaml
+#
+# (If the repo has a .sops.yaml creation rule for this path, `sops --encrypt`
+#  alone is enough.) The cluster FluxInstance already wires SOPS decryption via
+# the sops-age secret, so the encrypted file is decrypted automatically.
+#
+# NOTE: the secret MUST live in the flux-system namespace - substituteFrom
+# resolves secrets in the same namespace as the Kustomization (flux-system).
+# ---------------------------------------------------------------------------
+---
+apiVersion: v1
+kind: Secret
+metadata:
+  name: backstage-secrets-subst
+  namespace: flux-system
+type: Opaque
+stringData:
+  # --- GitHub integration (catalog ingestion + OAuth sign-in) ---
+  BACKSTAGE_GITHUB_TOKEN: "REPLACE_ME"          # PAT with repo + org read scope
+  BACKSTAGE_GITHUB_CLIENT_ID: "REPLACE_ME"      # GitHub OAuth App client id
+  BACKSTAGE_GITHUB_CLIENT_SECRET: "REPLACE_ME"  # GitHub OAuth App client secret
+
+  # --- Backend service-to-service auth ---
+  BACKSTAGE_BACKEND_SECRET: "REPLACE_ME"        # random 32+ byte base64 string
+  BACKSTAGE_EXTERNAL_ACCESS_TOKEN: "REPLACE_ME" # static token for dapr-workflow-service
+
+  # --- Database ---
+  BACKSTAGE_POSTGRESQL_PASSWORD: "REPLACE_ME"
+
+  # --- OIDC / Zitadel (optional; leave blank if AUTH_OIDC_ENABLED=false) ---
+  BACKSTAGE_ZITADEL_ISSUER: ""
+  BACKSTAGE_ZITADEL_CLIENT_ID: ""
+  BACKSTAGE_ZITADEL_CLIENT_SECRET: ""

--- a/clusters/platform/backstage.yaml
+++ b/clusters/platform/backstage.yaml
@@ -1,0 +1,57 @@
+---
+apiVersion: kustomize.toolkit.fluxcd.io/v1
+kind: Kustomization
+metadata:
+  name: backstage
+  namespace: flux-system
+spec:
+  interval: 1h
+  retryInterval: 1m
+  timeout: 5m
+  sourceRef:
+    kind: GitRepository
+    name: flux-apps
+  path: ./apps/backstage
+  prune: true
+  wait: true
+  postBuild:
+    substitute:
+      BACKSTAGE_NAMESPACE: backstage
+      BACKSTAGE_VERSION: "2.6.3"
+      BACKSTAGE_IMAGE_REGISTRY: ghcr.io
+      BACKSTAGE_IMAGE_REPOSITORY: stuttgart-things/sthings-backstage
+      BACKSTAGE_IMAGE_TAG: "v1.4.0"
+      BACKSTAGE_STORAGE_CLASS: nfs4-csi
+      BACKSTAGE_REPLICAS: "1"
+      BACKSTAGE_APP_TITLE: Stuttgart Things Backstage (Edge)
+      BACKSTAGE_ORGANIZATION_NAME: stuttgart-things
+      DOMAIN: platform.sthings.lab
+      GATEWAY_NAME: platform-sthings-gateway
+      GATEWAY_NAMESPACE: default
+    substituteFrom:
+      - kind: Secret
+        name: backstage-secrets-subst
+  patches:
+    - target:
+        kind: HelmRelease
+        name: backstage-deployment
+      patch: |
+        apiVersion: helm.toolkit.fluxcd.io/v2
+        kind: HelmRelease
+        metadata:
+          name: backstage-deployment
+        spec:
+          values:
+            backstage:
+              extraVolumes:
+                - name: trust-bundle
+                  configMap:
+                    name: cluster-trust-bundle
+                    optional: true
+              extraVolumeMounts:
+                - name: trust-bundle
+                  mountPath: /etc/ssl/custom/trust-bundle.pem
+                  subPath: trust-bundle.pem
+                  readOnly: true
+              extraEnvVarsCM:
+                - backstage-ca-env


### PR DESCRIPTION
## What

Deploys a Backstage instance on the harvester **platform** edge cluster (`platform.sthings.lab`) via Flux, reusing the shared `./apps/backstage` chart.

### New files (`clusters/platform/`)
- `backstage.yaml` — Flux `Kustomization` (source `flux-apps`, path `./apps/backstage`). Values derived from the cluster's `infra.yaml`: gateway `platform-sthings-gateway`/ns `default`, `DOMAIN: platform.sthings.lab`, image `ghcr.io/stuttgart-things/sthings-backstage:v1.4.0`, chart `2.6.3`.
- `backstage-prereqs.yaml` — namespace, `backstage-ca-env`, and the `backstage-catalog-config` ConfigMap wired to the curated **`sthings-harvester`** profile (no production root catalog → clean separation).
- `backstage-secrets.enc.yaml.example` — plaintext skeleton for the `backstage-secrets-subst` secret (`.example` so Flux ignores it). Fill in and SOPS-encrypt into `backstage-secrets.enc.yaml`.

## Why

Stands up a separate edge developer portal with its own curated template set, without forking the Backstage image or Helm chart.

## Before this reconciles green

- [ ] Provide `clusters/platform/backstage-secrets.enc.yaml` (SOPS-encrypted from the `.example`).
- [ ] Confirm the `nfs-csi` StorageClass name is `nfs4-csi` (set as `BACKSTAGE_STORAGE_CLASS`).
- [ ] Ensure the `flux-apps` GitRepository is applied on the cluster (bootstrapped out-of-band per the platform README).

## Related

Depends on `stuttgart-things/backstage-resources` PR adding the `sthings-harvester` catalog profile (referenced at `/blob/main/...`). Merge that first.

https://claude.ai/code/session_019Zdrnj4QkgWRZWtVNbS8j2

---
_Generated by [Claude Code](https://claude.ai/code/session_019Zdrnj4QkgWRZWtVNbS8j2)_