### PR TITLE
feat(platform): add argo-cd secrets (sops-age-key + admin password)

### DIFF
--- a/clusters/platform/apps/argocd-secrets.enc.yaml
+++ b/clusters/platform/apps/argocd-secrets.enc.yaml
@@ -1,0 +1,28 @@
+apiVersion: ENC[AES256_GCM,data:AQ8=,iv:N7fOYZN8Ki1qrjSC0wqg8py1UQQHmAxVRCl+KqBXZQE=,tag:dOtbGDkUPb3A6FGb8vBOzw==,type:str]
+kind: ENC[AES256_GCM,data:HT14A366,iv:KKGfZBx/iK5xRdeaEzwuS61ineOKNtr79Ang4dxeHOg=,tag:HL5Edd2h6NOfLN8mvGTGuw==,type:str]
+metadata:
+    name: ENC[AES256_GCM,data:6mFcL76Ytc7zz0blOKA=,iv:ApjWfxY9e+Z8snCwkEIxNexbK/r0cngyrwfI6fEO8to=,tag:Zh66HAhpQJREvwLXHvvxNQ==,type:str]
+    namespace: ENC[AES256_GCM,data:YOQJvHDWMNYwym0=,iv:5rb86rQvFbVsLGissGYUTN0RMm/SBp8tAEvGnzPdktw=,tag:jItfHCF48cyO74JkN+P1TQ==,type:str]
+type: ENC[AES256_GCM,data:md4S8APM,iv:9j7Juzp2HorT+PsXJc8p1lm+xC+Qv3CAldaEhF//qJc=,tag:CyDgQ3D4UxGeuZgn2cjMWA==,type:str]
+stringData:
+    ARGO_CD_SERVER_ADMIN_PASSWORD: ENC[AES256_GCM,data:QzSfqePtTT63MSwqR2uMwpkBbI6qWK2pFmbEbZHDVN5GMKDLmvXKpxwMAx2oaMTBHsmBSLjLP31SclN+,iv:UIYuLwmqww2u0W0xw1rVwk1iy+V/oqRORCEXCOSoosc=,tag:1MmXb9cnS+ZL60D7oD3vOQ==,type:str]
+sops:
+    kms: []
+    gcp_kms: []
+    azure_kv: []
+    hc_vault: []
+    age:
+        - recipient: age19vgzvmpt9tdlcsu8rzaacj397yz8gguz38nsmuy6eeelt5vjsyms542xtm
+          enc: |
+            -----BEGIN AGE ENCRYPTED FILE-----
+            YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSBaSHplNGd5aFdGTVV1NDVm
+            K2ptMVFFU0ROVXJlMnNKMVdYaWthSys2c1hnCk5iWTZ4ME55bGk1SjRTejdWMTBv
+            TGFobUVBeTVWWUllOWdSQzFCSDNOWlEKLS0tIEoyNjJ0dG1WaTY3MDh3SXNrd054
+            NG45N0xxU0t5SW9zVU5Db282Z0hOWTAKXF6mNMZfQVWEyTxSEQ+egUD2vzu1dTmD
+            VWtWeMjucM9sJiFWEj87qi9qRu5tVvxQRWCZ6p+jifx/ROcR+QpW9g==
+            -----END AGE ENCRYPTED FILE-----
+    lastmodified: "2026-06-05T08:36:48Z"
+    mac: ENC[AES256_GCM,data:yMDH4M4YqbXUPTL1JJYVjAyOOMyg3iGHoGC1KT0jsJ0fpdCNcJu586dcwcTBoriJH3fMEoPrbdRicDoySsrnWlQxLljt1q/5Hx/YeSnB/v5QxlZdSUR/bJLzI8GqziDK/VjO9i7/cBAO3z4wluCOiiohK0GgFgwqXSsjlSCZP3g=,iv:HXe0GJBo651RTIgMmAxl3dGF3O/D3RNUZ/2qE/25gtk=,tag:CMSYVI9EzEw5rBsEkiD1yQ==,type:str]
+    pgp: []
+    unencrypted_suffix: _unencrypted
+    version: 3.9.4

--- a/clusters/platform/apps/argocd-sops-age-key.enc.yaml
+++ b/clusters/platform/apps/argocd-sops-age-key.enc.yaml
@@ -1,0 +1,55 @@
+#ENC[AES256_GCM,data:ROjgoep1ytOzl4GVGeLpMmArL34RsHM5GCSHehaU/sJ+KZmxDe0JvvSgo5u5H/kHiIAbTi8IHo86omda87CWQ0H/S0+meF/BygufWjE=,iv:UGNEmX9py9M3XTbC0kIM7T6b4uR6Hj32bCYpNCn97A8=,tag:sl9jmYw/c83WaS6pw8zfMw==,type:comment]
+#ENC[AES256_GCM,data:PfdvGvINnQHGc/Pu3nCdeUHeRE6lHAUzNxePFXnTp0Kj64/yE2Y=,iv:orwoKhFQMT63Meq6rIm/La/woRXVx5GaONpY49qtSos=,tag:yShHAhoC4GA7YFQr2r6nPg==,type:comment]
+#
+#ENC[AES256_GCM,data:ODd8iOAL1gGC7pa6iaOruRtyMEYx/vAHw1HCvG6UxfgzLInFEO3jCX/gfc8YI0cJyJWcHf9ggTiIKfRp,iv:UAK4IyMPgu8HLlkW3BQucknLC+S71eX0O3BfKecJAZY=,tag:gStXWlZQ0K+mLP7y4XyDwg==,type:comment]
+#
+#ENC[AES256_GCM,data:ZIfzdS9dFIU=,iv:CWnXtt9+s5t0cPH+rnRbY7t02yP5T99nGqGBk3lHASo=,tag:QFPP9to04DMAQBcbXJXcHw==,type:comment]
+#ENC[AES256_GCM,data:ALn6Znn0HXSo+jRUYbFl6X/DkDo71fABbLFwtzLUeTuNI0xmRkJM8CD+bg5hPZsXo0n+h79t3sgFGQDaouicU9RdxTwZWE9L,iv:bjgdNV90Yin4tAjLOfeL1FlcE8Y03ArgNPOWlGsmCUs=,tag:txL5qRWxYigv5gPopUe0YQ==,type:comment]
+#ENC[AES256_GCM,data:1ikshmKtu4J03+lUfnC+NQLhFpNrsm/plWSm7lr8ihLAnTyrOkg9LYZSacL0QC1YzqMuf4mf5V1RGKIFTMdL7sWNLOrVx4K4qgg=,iv:V03Uxa4XBa9wMBA7qYLzt0XVx5Vyp9J1RuqrtErRVlc=,tag:SOzbewE2xwmfvi8b7BJmQA==,type:comment]
+#ENC[AES256_GCM,data:aCvLeRIvxYj6gJecyuOw2OZk9DArL/Se/DK3I5PTPwgFszwhZjtpMCNFaQdHnNFt2+dyAYkvmC1tZ/8EmfXx1Ya0nhBQvV/diYvojdnsh9M=,iv:aS3Y70TDhJ4u8gQ1nULaywBqjACLh1QjyLnIxpaafMY=,tag:ZhYzHlDT4JhfLmxizT6G5A==,type:comment]
+#
+#ENC[AES256_GCM,data:WXzASSgcpK2A9HsDwpVUn5GmtXrzeE9HY0M02Ys=,iv:fdq9xmRwprs6z9b2JrCgkrr+9hpeWjRLYdSDxui44JA=,tag:rOSyCj40ukAFtetPRcIETA==,type:comment]
+#ENC[AES256_GCM,data:RZfWCeHfRqknvZWCYBK7aU9ZF1uziPgKsi2T5JKnkQ4JuKuwmJ5Gg8/PsLLPOJ2u7ioHFb/VHrm97wEm5cGkWHg949S/kMvm,iv:MRMDwv0plnaPweFSsZs+zWMRZkXTL/v5jnGTKzo0ToY=,tag:n8f3aYr6ZXsghOE9kR35yA==,type:comment]
+#ENC[AES256_GCM,data:90LKSxR8Xv9KBoP4cSno3ENiMyh9UbLWt/iuDaZyVTwuLQqaEQukswlOfWdrphnY/y915fRTE5mfcHU4/YES+A==,iv:JY4E2Rvjfh7x1WKIUUnGi1ofbOnyLLywRdFVbUL23Ng=,tag:yDIjbtGbosDHrB39UC5TEg==,type:comment]
+#
+#ENC[AES256_GCM,data:xh3SUriZd2R8ueJiXZQ6wE+UU0mQOYUIj2zYLG8NpKFmM/yD97kBCYrPrUybu4hRhA==,iv:Tiv3WJMBQaegV76lu2cfVahsghLIEZpEA232kNr3HgI=,tag:F0UsKfqzErphySJTJ54XBA==,type:comment]
+#ENC[AES256_GCM,data:dXb9mItQ4WDIV8x7S0SEUCK+NN6+M7m0l5WHy2Y2ZQbOzJBQ6uYeD6odjQgtyHjIFS38Ow==,iv:mcBs7MbxnUyyHQXfRaaQO4w1a3EynyUQ9CBLxW8wY6s=,tag:L1TSW1L1LV7L25G4fbt4bw==,type:comment]
+#
+#ENC[AES256_GCM,data:WgoKUjYkCuVifMXNfPejPe2oWFfMhu8C1M538IcmQJjVKmkXSXkS3kL7OphLupcHI/Yt90KaGFkocy/dfuyhuQ==,iv:WCjkjxuXpxYX7IJYNUnkE6FhTXAL4DsHq3npeSTETI0=,tag:oztXD2pCYjJNBCnzJNduDA==,type:comment]
+#ENC[AES256_GCM,data:ToikQbjrm65U+9Y6e3YFHzfp2gWtkpMr1Agw5EEG8h4yV0ZiTRZb7Y2UoCtz1uXZVHgrUZuPyD9v,iv:McSSHG4cack0VWMh/jN3K/qP1QsKN8qWr7na0kbyHao=,tag:lN5ELWC0u+gMT/H1U56UVw==,type:comment]
+#
+#ENC[AES256_GCM,data:yooa2oxIpeSCwTDWR7wiOwoYm/Vjdw==,iv:woDqRshavLgspAKEVfEwS0R1KxrKMHm0ET0WwZuQufk=,tag:vWr8dVR24zOUPxYsY2ROGA==,type:comment]
+#ENC[AES256_GCM,data:Xbcd6dZqSo0O3wwtulCxWYS2UsnZN6oaSxp8lulqeN3AG2rKzWw2YXPIWy2JXx6ktP9I+btf2tsxcs69xhiN1t/m8xOCcNuss0L2loLnYk2p9HR+xmtuXYY=,iv:W0dlxMChGPhF6llCNfFsv/xZREUgGBp7/2AmRG7rukw=,tag:EDmSxWOXCljTkacZFofu6A==,type:comment]
+#
+#ENC[AES256_GCM,data:mav8TiAuBkLBYHYEkUYJxOfH28TMJ1oQWowNoYpRYzpSPdbxkiwvvLHkonbKOtv51a2PMYSL0IaqEJunIo3d9H4p7A==,iv:2Tx5rsdCxjsyktUSlwUVSNjtXAlhlk7AEZqPBEAfQbU=,tag:9TgZlIu2BqKuQ+IjLWkK7A==,type:comment]
+#ENC[AES256_GCM,data:iVuMRXr0Ki6BCygjtfV8T4hJqzRWW/TiqnOVh+nclP8M3f+6Hg==,iv:rSLgTmtmJhO2wC91oApbpaMhYjxCee3dOnNRe1JLDZw=,tag:IYyHEtgljDlNlUDTpuIEaQ==,type:comment]
+#ENC[AES256_GCM,data:tcbH0oquwXDJY/ZgIY4c5BIZVyb3nzpgBBgwiEZ29n+6FPHvjgqHf0Wxaz19V07k0jOR/w==,iv:zVPSOKvll8wBeZ1KtepjYMNPbjSxRYhKfl033Xzk0G8=,tag:0rqBXp7S8c2H73IEJfyl4w==,type:comment]
+#ENC[AES256_GCM,data:eHntP6TNxRfQV9TqGKBEWReeJouFZIz88r8P4YSa,iv:I74hsbffoz1UKtsmAewTkpXYaKOHQpiQePf1RxBRRDQ=,tag:66VKTXu/9vZFS1GENHENLA==,type:comment]
+#ENC[AES256_GCM,data:DQ+Ggcm3jhUTcKc+macly4qZjvUYnw6yUMFpkRR1aNBw2RhssNZXB9uLIYDIm4Kele80,iv:aKAozNw54kcBGBhDeTmyubiHARtrf+2cEc1CgxELQz4=,tag:DZwImW/PQcOwv0gJlNdmkw==,type:comment]
+#
+#ENC[AES256_GCM,data:cwF1xRmHtvX8GjxJXFaOiDk26Y1g58gw1p+EokJp7eG16eX0l4j9cKfxtzIlsFhowxPQWYw6WKrOakZEqDRlWtkIh98=,iv:R2Vv4VUhiF1kFYnU1G6PAAhrQW2xNWsJd1firQxaJkg=,tag:CWtzxIe0ahdJj++PVSUFFA==,type:comment]
+#ENC[AES256_GCM,data:xAn9YN/HGLpI1TxMoyLAZBh3zLELxqBJR2Oh9GKB+Uhz2WBtnIP3,iv:acYGLAJNNMhJodGx2nvWnv0mU7E4WyF+IkuoWnR79+k=,tag:7IqMa9dHHj6so2CFf8pGJw==,type:comment]
+#ENC[AES256_GCM,data:nOKrBvX8xEQlc0hUxR9Yqmk0S6SD1BF7ttgoReQw8rs91ir+pcAE2tRyriI60y65RVt1MIxGrmIELVOcILY/fdTVMtcsnEDsVVpYRgk=,iv:aZ2uQdLoYh/4KXKARvAiVVrwXara+sXZ9ggGE0NMRzU=,tag:nerjIL40dgqhBxGiVVhRDw==,type:comment]
+apiVersion: ENC[AES256_GCM,data:R0U=,iv:ei6T4QGn3baXYrAAoe9Guq4yzdpJey4KnvSDU+Pd3qw=,tag:Hcrlc4i+qGt3FBhJFvo3lg==,type:str]
+kind: ENC[AES256_GCM,data:bljBI/zt,iv:ZjXOOBG/4JHdLDIsnMA+8m8Ruw2K7T8ZaJyg2y9Vuf4=,tag:UCFNonnrIiaA8Hq+XDQtgg==,type:str]
+metadata:
+    name: ENC[AES256_GCM,data:BOkPSE2WaN9LM1Q94X2lMI3PXQ==,iv:yVPjZikyS+oPyvWmfg4nh3Fsdjr2Idowcu43GY8BTQ0=,tag:dWJEl5q7Sfip2tdlAsuYeQ==,type:str]
+    namespace: ENC[AES256_GCM,data:88Bvy4NO,iv:wzEt/4w0oNAKwVCie6oX+CqnjC4DIf4qsvW2fKIST4M=,tag:oCREhKKqMZ2O8WNVY+CZyA==,type:str]
+type: ENC[AES256_GCM,data:K9MupvIZ,iv:tDdGNPDMi2xFs4bivVxYl+TaevX3MxKjCwAtw9nF8so=,tag:9wyUZqItFNZhcYIH5O6CSg==,type:str]
+stringData:
+    keys.txt: ENC[AES256_GCM,data:iS8Mb/EkN9dAODUvGdGQcv88VR6ZpZ/mChZhstGK2FQA63y9pLKXQMU1Lrag9vWZEK4zf8zbXRxXLocRW5hVp2Wv1WgQ8h3PNsq5Q9CnazlljLbTR4A+ohdbvKiaJl0W2A9BlyecOZVdUrs5y6e8eInu+zyERqsW1dYZJoeqzJ7dEQK527laIXfM80+zBi6d2aWMihGl0o6NlaHQx1DA49lUz+qDRp/fpo2bOKRu5v6x/irr36BKk4S4,iv:5/D2CfwA+WTqr+7FzRyfcXquHG7ii6LNoUXY0houJfA=,tag:0ZhX+Vf5g/9jGUnMHPvcdw==,type:str]
+sops:
+    age:
+        - recipient: age19vgzvmpt9tdlcsu8rzaacj397yz8gguz38nsmuy6eeelt5vjsyms542xtm
+          enc: |
+            -----BEGIN AGE ENCRYPTED FILE-----
+            YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSBlWjRhaGFKUjV5eW1paU03
+            c1ppQzV4emxOMFBjK08yS0k4bWI5YUc2NjNJCllZZ2h5R2p2dkNzbEpjZVZRQlNr
+            MXM0RTlqazR2T0xMazZjckI3QkwySlUKLS0tIGxPdGI2K3NzaWlKa2l0VndvTEtT
+            MVJ0amEyVmpqSnlIOG5BcFJOcDFuRG8K6dNv7yG0cLsrqYdohXPjM33D8EGdldj2
+            vR0QD/oiSAsmbLunHFRjf3BY9JdDzI4riSnceatgxVzZHIfdWUSe/g==
+            -----END AGE ENCRYPTED FILE-----
+    lastmodified: "2026-04-19T04:02:14Z"
+    mac: ENC[AES256_GCM,data:aJsSJVvt4UxsbmCHGcpT237Kd96MIpueu7U2eFC+kW4NyWxg3SnawBl/W87x3hQtJw46QzxiSA0HeOrq1vnxSumUuWFvNtVTRC6UYpJYkIG/7F5ZkFPrC2WW8b59+XygSVJkL5Qy+YZGZIdkJpQo0l9tcCpsAq3HCvDqb5RuepI=,iv:Lx2j+iYTlywP0YGgiUkZgeYWwTFP7LjDPacPOgunAVs=,tag:I4a/LUnfKkeRGW+DkzCavg==,type:str]
+    unencrypted_suffix: _unencrypted
+    version: 3.12.2


### PR DESCRIPTION
## Complete argo-cd: add its two required secrets

The argo-cd manifests (`argo-cd.yaml`, `argo-cd-httproute.yaml`) are already on `main` (#67), but the `argo-cd` Kustomization errors without its secrets. This adds both so it reconciles cleanly. (Supersedes the revert PR #73, now closed.)

### Files
- `clusters/platform/apps/argocd-sops-age-key.enc.yaml` — age **private** key for Argo CD's SOPS config-management-plugin sidecar. Copied verbatim from the platform-sthings example (same age recipient, so it decrypts in-cluster). Flux decrypts it into the `argocd-sops-age-key` Secret, which the repo-server CMP mounts at `/.config/sops/age/keys.txt` to decrypt SOPS files in the apps Argo CD syncs.
- `clusters/platform/apps/argocd-secrets.enc.yaml` — provides `ARGO_CD_SERVER_ADMIN_PASSWORD` (a **bcrypt hash** of the admin password, as the argo-cd chart expects). Consumed via the `argo-cd` Kustomization `substituteFrom`.

Both are SOPS-encrypted to `age19vgz…542xtm` (same key as the rancher/harbor/minio secrets) and excluded from the lint gate by the `.enc.yaml` rule.

### Result
With these in place, the repo-server CMP sidecar starts (age key mounted) and the admin login works (`admin` / your password). Once merged, the `argo-cd` and `argo-cd-httproute` Kustomizations go Ready.

https://claude.ai/code/session_014x4LVcwkrq73KDcKWLb8Wa

---
_Generated by [Claude Code](https://claude.ai/code/session_014x4LVcwkrq73KDcKWLb8Wa)_