### PR TITLE
fix(platform): pre-create argocd namespace to break bootstrap deadlock

### DIFF
--- a/clusters/platform/apps/argocd-namespace.yaml
+++ b/clusters/platform/apps/argocd-namespace.yaml
@@ -1,0 +1,13 @@
+---
+# Create the argocd namespace in the platform sync so the SOPS-encrypted
+# argocd-sops-age-key Secret (namespace: argocd) can be applied before the
+# argo-cd app itself runs. Without this the flux-system sync fails the whole
+# batch with "namespaces argocd not found", which also blocks argocd-secrets
+# and deadlocks the argo-cd Kustomization. Labels match cicd/argo-cd's
+# requirements.yaml so the two managers agree on the object.
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: argocd
+  labels:
+    toolkit.fluxcd.io/tenant: sthings-team


### PR DESCRIPTION
## Fix argo-cd bootstrap deadlock — pre-create the `argocd` namespace

After merging the argo-cd secrets (#74), the `flux-system` sync started failing the **entire** `clusters/platform` apply with:

```
Secret/argocd/argocd-sops-age-key not found: namespaces "argocd" not found
```

### Root cause
- `argocd-sops-age-key` is namespaced to **`argocd`**.
- That namespace is only created by the argo-cd app (`cicd/argo-cd/requirements.yaml`), which can't run yet because its Kustomization needs `argocd-secrets`.
- Flux validates the apply as a batch, so the missing namespace fails the whole set — meaning `argocd-secrets` (namespace `flux-system`) **also never gets created**, which blocks the `argo-cd` Kustomization build. Deadlock.

### Fix
Add a `Namespace/argocd` manifest to the platform sync so the namespace exists **before** the age-key Secret is applied. The batch then succeeds, `argocd-secrets` is created, and `argo-cd` builds normally. Labels match `cicd/argo-cd`'s namespace so the two managers agree on the object (benign shared ownership).

### File
- `clusters/platform/apps/argocd-namespace.yaml`

This makes the fix reproducible in Git (a fresh cluster won't hit the deadlock). On the live cluster I also gave a one-time `kubectl create namespace argocd` to unblock immediately.

https://claude.ai/code/session_014x4LVcwkrq73KDcKWLb8Wa

---
_Generated by [Claude Code](https://claude.ai/code/session_014x4LVcwkrq73KDcKWLb8Wa)_