### PR TITLE
feat(platform): deploy trust-manager (rancher tls-ca + cluster trust bundle)

### DIFF
--- a/clusters/platform/infra.yaml
+++ b/clusters/platform/infra.yaml
@@ -114,3 +114,34 @@ spec:
       NFS_CSI_VERSION: v4.13.1
       NFS_CSI_ENABLE_CRDS: "true"
       NFS_CSI_ENABLE_SNAPSHOTTER: "true"
+---
+apiVersion: kustomize.toolkit.fluxcd.io/v1
+kind: Kustomization
+metadata:
+  name: trust-manager
+  namespace: flux-system
+spec:
+  interval: 1h
+  retryInterval: 1m
+  timeout: 5m
+  dependsOn:
+    - name: cert-manager-selfsigned
+  sourceRef:
+    kind: GitRepository
+    name: flux-infra
+  path: ./infra/trust-manager
+  prune: true
+  wait: true
+  postBuild:
+    substitute:
+      TRUST_MANAGER_NAMESPACE: cert-manager
+      TRUST_MANAGER_VERSION: "0.22.0"
+      TRUST_BUNDLE_NAME: cluster-trust-bundle
+      TRUST_BUNDLE_CA_SECRET: cluster-ca-secret
+      TRUST_BUNDLE_CA_KEY: ca.crt
+      TRUST_BUNDLE_VAULT_CA_SECRET: vault-pki-ca
+      TRUST_BUNDLE_VAULT_CA_KEY: ca.crt
+      TRUST_BUNDLE_TARGET_KEY: trust-bundle.pem
+      TRUST_BUNDLE_SECRET_NAME: tls-ca
+      TRUST_BUNDLE_SECRET_TARGET_KEY: cacerts.pem
+      TRUST_BUNDLE_SECRET_NAMESPACE: cattle-system

--- a/clusters/platform/infra.yaml
+++ b/clusters/platform/infra.yaml
@@ -142,6 +142,6 @@ spec:
       TRUST_BUNDLE_VAULT_CA_SECRET: vault-pki-ca
       TRUST_BUNDLE_VAULT_CA_KEY: ca.crt
       TRUST_BUNDLE_TARGET_KEY: trust-bundle.pem
-      TRUST_BUNDLE_SECRET_NAME: tls-ca
-      TRUST_BUNDLE_SECRET_TARGET_KEY: cacerts.pem
-      TRUST_BUNDLE_SECRET_NAMESPACE: cattle-system
+      TRUST_BUNDLE_SECRET_NAME: tls-ca # pragma: allowlist secret
+      TRUST_BUNDLE_SECRET_TARGET_KEY: cacerts.pem # pragma: allowlist secret
+      TRUST_BUNDLE_SECRET_NAMESPACE: cattle-system # pragma: allowlist secret

--- a/clusters/platform/infra.yaml
+++ b/clusters/platform/infra.yaml
@@ -137,9 +137,9 @@ spec:
       TRUST_MANAGER_NAMESPACE: cert-manager
       TRUST_MANAGER_VERSION: "0.22.0"
       TRUST_BUNDLE_NAME: cluster-trust-bundle
-      TRUST_BUNDLE_CA_SECRET: cluster-ca-secret
+      TRUST_BUNDLE_CA_SECRET: cluster-ca-secret # pragma: allowlist secret
       TRUST_BUNDLE_CA_KEY: ca.crt
-      TRUST_BUNDLE_VAULT_CA_SECRET: vault-pki-ca
+      TRUST_BUNDLE_VAULT_CA_SECRET: vault-pki-ca # pragma: allowlist secret
       TRUST_BUNDLE_VAULT_CA_KEY: ca.crt
       TRUST_BUNDLE_TARGET_KEY: trust-bundle.pem
       TRUST_BUNDLE_SECRET_NAME: tls-ca # pragma: allowlist secret

--- a/tests/install.md
+++ b/tests/install.md
@@ -345,4 +345,3 @@ kubectl get virtualmachineimages.harvesterhci.io -A                # images -> A
 ```
 
 UI/API reachable at `https://<VIP>` (and `https://harvester-vip.sthings.lab` if the DNS record was added).
-


### PR DESCRIPTION
## Deploy trust-manager on the platform cluster

Adds a `trust-manager` Kustomization to `clusters/platform/infra.yaml`. This replaces the **manual `kubectl create secret tls-ca`** we did to get Rancher up, and is the mechanism the rancher app's README documents.

### What it does
trust-manager (`./infra/trust-manager` in `flux-infra`) creates two Bundles from the cluster CAs (`cluster-ca-secret` + `vault-pki-ca`, both in `cert-manager`, key `ca.crt` — verified on-cluster):

- **`tls-ca` Secret** (`cacerts.pem`) written into `cattle-system` → Rancher's `privateCA` mount. No more manual secret.
- **`cluster-trust-bundle` ConfigMap** (`trust-bundle.pem`) → consumed by argo-cd's argocd-vault-plugin (`AVP_TRUST_BUNDLE_CONFIGMAP`), currently optional/absent.

### Wiring
`dependsOn: cert-manager-selfsigned` (which creates `cluster-ca-secret`). Substitutions match the cluster's actual CA secrets/keys.

### After merge
Once the `tls-ca` Bundle is Ready, the hand-made secret can be removed so trust-manager owns it:
```bash
kubectl -n cattle-system delete secret tls-ca   # trust-manager recreates it
kubectl -n cattle-system get secret tls-ca       # owned by trust-manager (Bundle)
```

Part of retiring the manual bootstrap steps so a cluster rebuild is fully GitOps-managed.

https://claude.ai/code/session_014x4LVcwkrq73KDcKWLb8Wa

---
_Generated by [Claude Code](https://claude.ai/code/session_014x4LVcwkrq73KDcKWLb8Wa)_