### PR TITLE
fix(platform): disable harbor trivy + exporter on single-node cluster

### DIFF
--- a/clusters/platform/apps/harbor.yaml
+++ b/clusters/platform/apps/harbor.yaml
@@ -29,6 +29,20 @@ spec:
     - kind: Secret
       name: harbor-secrets
       optional: false
+  # Single-node platform cluster: keep harbor lean (registry / pull-through
+  # cache only). Disable trivy (vuln scanner) and exporter (metrics) so their
+  # CPU requests don't exceed the node's remaining allocatable.
+  patches:
+    - target:
+        kind: HelmRelease
+        name: harbor
+      patch: |
+        - op: add
+          path: /spec/values/trivy/enabled
+          value: false
+        - op: add
+          path: /spec/values/exporter/enabled
+          value: false
   prune: true
   retryInterval: '1m'
   sourceRef:


### PR DESCRIPTION
## Trim harbor for the single-node platform cluster

Harbor here is only a **registry / pull-through cache**, and the node's CPU **requests** are ~96% allocated (3850m / 4 cores) — even though real load is ~15%. That leaves no room for `harbor-trivy-0`, which sits `Pending` with `FailedScheduling: Insufficient cpu`.

### Change
Adds a cluster-local Flux `patches:` block to `clusters/platform/apps/harbor.yaml` that disables the two components not needed for a cache:

```yaml
- op: add
  path: /spec/values/trivy/enabled      # vulnerability scanner
  value: false
- op: add
  path: /spec/values/exporter/enabled   # prometheus metrics
  value: false
```

`core` / `registry` / `postgresql` / `redis` (already scheduled and running) are all that's needed. This is a patch on the harvester side only — no change to the shared `flux` harbor app, and trivially reversible when the cluster grows.

### After merge
```bash
flux reconcile kustomization flux-system --with-source
flux reconcile hr harbor -n harbor --force          # if still stalled
kubectl -n harbor get pods                          # trivy/exporter gone; rest Running
kubectl -n harbor delete pvc data-harbor-trivy-0    # orphaned trivy PVC, optional cleanup
```

Then configure a proxy-cache project for the pull-through behaviour (the example repo's `harbor-project-proxy.yaml` is the reference).

https://claude.ai/code/session_014x4LVcwkrq73KDcKWLb8Wa

---
_Generated by [Claude Code](https://claude.ai/code/session_014x4LVcwkrq73KDcKWLb8Wa)_