### PR TITLE
feat(platform): add harbor-project-proxy (pull-through cache)

### DIFF
--- a/clusters/platform/apps/harbor-project-proxy.yaml
+++ b/clusters/platform/apps/harbor-project-proxy.yaml
@@ -1,0 +1,40 @@
+---
+apiVersion: kustomize.toolkit.fluxcd.io/v1
+kind: Kustomization
+metadata:
+  labels:
+    app.kubernetes.io/managed-by: flux
+    kustomization.stuttgart-things.com/type: app
+  name: harbor-project-proxy
+  namespace: flux-system
+spec:
+  dependsOn:
+    - name: harbor
+  force: false
+  interval: '1h'
+  path: './apps/harbor/components/project-proxy'
+  postBuild:
+    substitute:
+      HARBOR_NAMESPACE: harbor
+      HARBOR_HOSTNAME: harbor
+      HARBOR_DOMAIN: platform.sthings.lab
+      # Exposure is via the Gateway API HTTPRoute (already deployed by the
+      # harbor-httproute Kustomization, which includes the wildcard
+      # *.harbor.<domain> route to the harbor-project-proxy service), so the
+      # chart's own nginx ingress is disabled.
+      INGRESS_ENABLED: 'false'
+      INGRESS_CLASS_NAME: nginx
+      HARBOR_PROJECT_PROXY_VERSION: '0.0.1'
+  prune: true
+  retryInterval: '1m'
+  sourceRef:
+    kind: GitRepository
+    name: flux-apps
+  suspend: false
+  timeout: '5m'
+  wait: true
+  healthChecks:
+    - apiVersion: helm.toolkit.fluxcd.io/v2
+      kind: HelmRelease
+      name: harbor-project-proxy
+      namespace: harbor


### PR DESCRIPTION
## Add harbor-project-proxy (pull-through cache front-end)

Deploys the `harbor-project-proxy` workload so harbor can be used as a transparent pull-through cache / image mirror. Follows the example cluster's setup, adapted for the platform cluster's Gateway API.

### How it fits together
- The **wildcard `*.harbor.platform.sthings.lab` HTTPRoute → `harbor-project-proxy` service** is *already* deployed (the `harbor-httproute` Kustomization includes `httproute-project-proxy.yaml`). It's been dangling with no backend — this adds that backend.
- So exposure is via the **Gateway/HTTPRoute**, and the chart's own nginx ingress is disabled (`INGRESS_ENABLED: false`).

### File
- `clusters/platform/apps/harbor-project-proxy.yaml` → `./apps/harbor/components/project-proxy` (chart `harbor-project-proxy@0.0.1`), `dependsOn: harbor`.

### Capacity note
This is a single small reverse-proxy pod (`replicaCount: 1`). It fits because #77 freed CPU by disabling trivy + exporter.

### After merge
```bash
flux reconcile kustomization flux-system --with-source
flux get hr -n harbor                         # harbor-project-proxy True
kubectl -n harbor get pods                     # harbor-project-proxy-… Running
```
Then create the proxy-cache **project** in harbor (e.g. `dockerhub` → `https://registry-1.docker.io`) and pull via `dockerhub.harbor.platform.sthings.lab/<image>`.

https://claude.ai/code/session_014x4LVcwkrq73KDcKWLb8Wa

---
_Generated by [Claude Code](https://claude.ai/code/session_014x4LVcwkrq73KDcKWLb8Wa)_