### PR TITLE
feat(platform): add *.harbor wildcard cert + gateway listener for pull-through cache

### DIFF
--- a/clusters/platform/infra.yaml
+++ b/clusters/platform/infra.yaml
@@ -77,6 +77,7 @@ spec:
   dependsOn:
     - name: cilium-lb
     - name: cert-manager-selfsigned
+    - name: cert-harbor-wildcard
   sourceRef:
     kind: GitRepository
     name: flux-infra
@@ -89,6 +90,57 @@ spec:
       CILIUM_GATEWAY_NAMESPACE: default
       CILIUM_GATEWAY_DOMAIN: "platform.sthings.lab"
       CILIUM_GATEWAY_TLS_SECRET: wildcard-platform-sthings-tls # pragma: allowlist secret
+  # Extra listener for the harbor pull-through-cache wildcard subdomain
+  # (*.harbor.<domain>) — the base *.<domain> cert/listener doesn't cover the
+  # two-level subdomain used by harbor-project-proxy.
+  patches:
+    - target:
+        group: gateway.networking.k8s.io
+        version: v1
+        kind: Gateway
+      patch: |
+        - op: add
+          path: /spec/listeners/-
+          value:
+            name: https-harbor
+            hostname: "*.harbor.platform.sthings.lab"
+            port: 443
+            protocol: HTTPS
+            allowedRoutes:
+              namespaces:
+                from: All
+            tls:
+              mode: Terminate
+              certificateRefs:
+                - kind: Secret
+                  group: ""
+                  name: wildcard-harbor-platform-sthings-tls
+---
+apiVersion: kustomize.toolkit.fluxcd.io/v1
+kind: Kustomization
+metadata:
+  name: cert-harbor-wildcard
+  namespace: flux-system
+spec:
+  interval: 1h
+  retryInterval: 1m
+  timeout: 5m
+  dependsOn:
+    - name: cert-manager-selfsigned
+  sourceRef:
+    kind: GitRepository
+    name: flux-infra
+  path: ./infra/cert-manager/components/extra-certificate
+  prune: true
+  wait: true
+  postBuild:
+    substitute:
+      EXTRA_CERT_NAME: wildcard-harbor-platform-sthings-tls
+      EXTRA_CERT_NAMESPACE: default
+      EXTRA_CERT_SECRET_NAME: wildcard-harbor-platform-sthings-tls # pragma: allowlist secret
+      EXTRA_CERT_DOMAIN: harbor.platform.sthings.lab
+      EXTRA_CERT_ISSUER: vault-pki
+      EXTRA_CERT_ISSUER_KIND: ClusterIssuer
 ---
 apiVersion: kustomize.toolkit.fluxcd.io/v1
 kind: Kustomization


### PR DESCRIPTION
## Add `*.harbor` wildcard cert + gateway listener (TLS for the pull-through cache)

The base gateway cert/listener is `*.platform.sthings.lab`, which does **not** cover the two-level `*.harbor.platform.sthings.lab` used by the harbor pull-through cache (`<project>.harbor.<domain>`). So pulls from the cache hit a TLS name/authority mismatch. This adds the missing wildcard — exactly matching the example cluster's setup.

### Changes (`clusters/platform/infra.yaml`)
1. **New `cert-harbor-wildcard` Kustomization** → `extra-certificate` component, issues `*.harbor.platform.sthings.lab` (ClusterIssuer `vault-pki`) into secret `wildcard-harbor-platform-sthings-tls`.
2. **Patch `cilium-gateway`** → appends an `https-harbor` listener for `*.harbor.platform.sthings.lab` referencing that secret, and adds `cert-harbor-wildcard` to its `dependsOn`.

Additive, low-risk (`op: add /spec/listeners/-`); the existing `*.platform.sthings.lab` listener is untouched.

### Note on client trust
This makes the gateway present a valid `*.harbor` cert, but it's signed by the **self-signed `vault-pki` CA**, so clients still need to trust that CA (or treat the registry as insecure) — e.g. drop `vault-pki-ca`'s `ca.crt` into `/etc/docker/certs.d/<host>/ca.crt` or `/etc/rancher/k3s/registries.yaml`. That's expected for an internal CA.

### After merge
```bash
flux reconcile kustomization flux-system --with-source
flux get kustomization cert-harbor-wildcard cilium-gateway -n flux-system   # both True
kubectl -n default get cert wildcard-harbor-platform-sthings-tls            # Ready
kubectl get gateway -n default platform-sthings-gateway -o yaml | grep -A3 https-harbor
```

https://claude.ai/code/session_014x4LVcwkrq73KDcKWLb8Wa

---
_Generated by [Claude Code](https://claude.ai/code/session_014x4LVcwkrq73KDcKWLb8Wa)_