### PR TITLE
fix(platform): drop harbor resource requests to fit single-node cluster

### DIFF
--- a/clusters/platform/apps/harbor.yaml
+++ b/clusters/platform/apps/harbor.yaml
@@ -30,8 +30,10 @@ spec:
       name: harbor-secrets
       optional: false
   # Single-node platform cluster: keep harbor lean (registry / pull-through
-  # cache only). Disable trivy (vuln scanner) and exporter (metrics) so their
-  # CPU requests don't exceed the node's remaining allocatable.
+  # cache only). Disable trivy (vuln scanner) and exporter (metrics), and drop
+  # resource requests to "none" — the node's CPU requests are already ~96%
+  # allocated (yet only ~15% used), so the default presets prevent the
+  # rolling-update surge pods from scheduling.
   patches:
     - target:
         kind: HelmRelease
@@ -43,6 +45,27 @@ spec:
         - op: add
           path: /spec/values/exporter/enabled
           value: false
+        - op: add
+          path: /spec/values/core/resourcesPreset
+          value: none
+        - op: add
+          path: /spec/values/jobservice/resourcesPreset
+          value: none
+        - op: add
+          path: /spec/values/portal/resourcesPreset
+          value: none
+        - op: add
+          path: /spec/values/registry/server/resourcesPreset
+          value: none
+        - op: add
+          path: /spec/values/registry/controller/resourcesPreset
+          value: none
+        - op: add
+          path: /spec/values/postgresql/primary/resourcesPreset
+          value: none
+        - op: add
+          path: /spec/values/redis/master/resourcesPreset
+          value: none
   prune: true
   retryInterval: '1m'
   sourceRef:


### PR DESCRIPTION
## Right-size harbor so it fits the single-node cluster

The harbor HelmRelease is stuck `Failed to upgrade` — the rolling-update **surge** pods for `harbor-core` / `harbor-jobservice` / `harbor-registry` are `Pending` with `Insufficient cpu`. The node is at **~96% CPU requests** (but only ~15% real usage), so there's no room for the second copy during a rollout.

Disabling trivy (PR #77) didn't help because **trivy was never scheduled** — it held no allocation. The block is the *running* harbor pods' default request presets.

### Change
Extends the `harbor.yaml` patch to set `resourcesPreset: none` on harbor's components (core, jobservice, portal, registry server+controller, postgresql, redis), removing their CPU/memory requests. Real usage is tiny, so this is safe on a lab node and lets the rollout's surge pods schedule.

### After merge
```bash
flux reconcile kustomization flux-system --with-source
flux reconcile hr harbor -n harbor --force
# or, since it's Stalled:
flux suspend hr harbor -n harbor && flux resume hr harbor -n harbor

kubectl -n harbor get pods           # new core/jobservice/registry pods schedule; old ones terminate
flux get hr -n harbor                 # harbor True
```

### Bigger picture
This is the cluster-wide over-request issue surfacing on harbor (96% reserved / 15% used). The durable fix is trimming default requests on the heavy apps (argo-cd repo-server's 6 sidecars especially) — happy to follow up on that.

https://claude.ai/code/session_014x4LVcwkrq73KDcKWLb8Wa

---
_Generated by [Claude Code](https://claude.ai/code/session_014x4LVcwkrq73KDcKWLb8Wa)_