### PR TITLE
fix(platform): repair harbor kustomize build (invalid resourcesPreset paths)

### DIFF
--- a/clusters/platform/apps/harbor.yaml
+++ b/clusters/platform/apps/harbor.yaml
@@ -60,12 +60,6 @@ spec:
         - op: add
           path: /spec/values/registry/controller/resourcesPreset
           value: none
-        - op: add
-          path: /spec/values/postgresql/primary/resourcesPreset
-          value: none
-        - op: add
-          path: /spec/values/redis/master/resourcesPreset
-          value: none
   prune: true
   retryInterval: '1m'
   sourceRef:


### PR DESCRIPTION
## Fix the harbor kustomize build (drop invalid postgres/redis patch ops)

PR #80's patch included two JSON6902 `add` ops whose parent paths don't exist in the HelmRelease values (`postgresql.primary`, `redis.master` — only `.image` is defined), so the **entire patch failed to build** and the `harbor` Kustomization went red:

```
add operation does not apply: doc is missing path: "/spec/values/postgresql/primary/resourcesPreset"
```

This removes those two ops. The remaining presets (`core`, `jobservice`, `portal`, `registry.server`, `registry.controller`) all target existing paths and are sufficient — postgres/redis are single StatefulSets that were never the scheduling bottleneck.

### Context
On the cluster, harbor's pods are already `Running` (the stuck deployments were manually recreated, which broke the rolling-update surge deadlock). This fix just lets Flux build/apply the harbor Kustomization again so it reconciles to `True`.

### After merge
```bash
flux reconcile kustomization flux-system --with-source
flux reconcile hr harbor -n harbor --force
flux get kustomizations -n flux-system | grep harbor     # harbor True; httproute + project-proxy unblock
```

https://claude.ai/code/session_014x4LVcwkrq73KDcKWLb8Wa

---
_Generated by [Claude Code](https://claude.ai/code/session_014x4LVcwkrq73KDcKWLb8Wa)_