### PR TITLE
feat(platform): migrate argo-cd to argocd-platform bundle (base)

### DIFF
--- a/clusters/platform/apps/argo-cd-httproute.yaml
+++ b/clusters/platform/apps/argo-cd-httproute.yaml
@@ -15,7 +15,7 @@ spec:
   prune: true
   wait: true
   dependsOn:
-    - name: argo-cd
+    - name: argocd-platform-argo-cd
   postBuild:
     substitute:
       ARGO_CD_NAMESPACE: argocd

--- a/clusters/platform/apps/argocd-platform.yaml
+++ b/clusters/platform/apps/argocd-platform.yaml
@@ -1,21 +1,34 @@
 ---
+# argocd-platform bundle (base scope): stands up Argo CD (same cicd/argo-cd
+# install as before) + clusterbook-operator + argocd-config (AppProjects +
+# cluster-generator ApplicationSet), all dependsOn-ordered. Replaces the
+# standalone clusters/platform/apps/argo-cd.yaml Kustomization.
+#
+# Platforms are opt-in: point at ./cicd/argocd-platform/overlays/full (or a
+# trimmed overlay) and add the argocd-catalog GitRepository source to enable
+# catalog platform stacks. Base needs only flux-apps + argocd-secrets.
 apiVersion: kustomize.toolkit.fluxcd.io/v1
 kind: Kustomization
 metadata:
-  name: argo-cd
+  labels:
+    app.kubernetes.io/managed-by: flux
+    kustomization.stuttgart-things.com/type: cicd
+  name: argocd-platform
   namespace: flux-system
 spec:
   interval: 1h
   retryInterval: 1m
-  timeout: 5m
+  timeout: 10m
   sourceRef:
     kind: GitRepository
     name: flux-apps
-  path: ./cicd/argo-cd
+  path: ./cicd/argocd-platform/base
   prune: true
   wait: true
   postBuild:
     substitute:
+      BUNDLE_NAME: argocd-platform
+      FLUX_SOURCE: flux-apps
       ARGO_CD_VERSION: "9.4.15"
       ARGO_CD_NAMESPACE: argocd
       ARGO_CD_INGRESS_ENABLED: "false"
@@ -28,11 +41,8 @@ spec:
       AVP_TRUST_BUNDLE_CONFIGMAP: cluster-trust-bundle
       AVP_TRUST_BUNDLE_KEY: trust-bundle.pem
       AVP_SSL_CERT_DIR: /etc/ssl/custom
+      CLUSTERBOOK_OPERATOR_NAMESPACE: clusterbook-system
+      CLUSTERBOOK_OPERATOR_VERSION: v0.19.0
     substituteFrom:
       - kind: Secret
         name: argocd-secrets
-  healthChecks:
-    - apiVersion: helm.toolkit.fluxcd.io/v2
-      kind: HelmRelease
-      name: argocd-deployment
-      namespace: argocd


### PR DESCRIPTION
## Migrate Argo CD to the `argocd-platform` bundle (base scope)

Adopts the [`cicd/argocd-platform`](https://github.com/stuttgart-things/flux/tree/main/cicd/argocd-platform) bundle. **This does not destroy Argo CD** — the bundle's `ks-argo-cd` points at the **same `./cicd/argo-cd`** install (same chart, `HelmRelease/argocd-deployment`, `argocd` namespace, same `argocd-secrets`). It just wraps it with two extras, dependsOn-ordered:

- **clusterbook-operator** (`clusterbook-system`) — registers downstream clusters as Argo cluster-secrets + stamps labels
- **argocd-config** — AppProjects + the cluster-generator ApplicationSet

### Changes
- ➖ `clusters/platform/apps/argo-cd.yaml` (standalone) → ➕ `clusters/platform/apps/argocd-platform.yaml` (bundle, `path: ./cicd/argocd-platform/base`)
- `argo-cd-httproute.yaml`: `dependsOn` repointed `argo-cd` → `argocd-platform-argo-cd`
- **Kept as-is:** `argocd-secrets`, `argocd-sops-age-key`, `argocd-namespace` (the bundle reuses them)

### Scope
**base only** — just Argo CD + operator + config. No platform components, so no new sources needed (`argocd-catalog` is only required when enabling catalog platforms). Easy to extend later by pointing at an overlay.

### Expected on reconcile (one-time, harmless)
Because the managing Kustomization changes name (`argo-cd` → `argocd-platform-argo-cd`), Flux prunes the old `argocd-deployment` and the bundle recreates it → **Argo CD pods cycle once** (images cached, ~1 min). No data loss — there are no Argo Applications yet.

```bash
flux reconcile kustomization flux-system --with-source
flux get kustomizations -n flux-system | grep -E 'argocd-platform|argo-cd-httproute|clusterbook'
#   argocd-platform, argocd-platform-argo-cd, argocd-platform-clusterbook-operator,
#   argocd-platform-argocd-config, argo-cd-httproute → all True
kubectl -n argocd get pods
kubectl -n clusterbook-system get pods
```
If the bundle's argo-cd HR shows the first-install `--wait` stall: `flux reconcile hr argocd-deployment -n argocd --force`.

https://claude.ai/code/session_014x4LVcwkrq73KDcKWLb8Wa

---
_Generated by [Claude Code](https://claude.ai/code/session_014x4LVcwkrq73KDcKWLb8Wa)_