### PR TITLE
feat(platform): seed clusterbook ProviderConfig (parameterized)

### DIFF
--- a/clusters/platform/clusterbook-providerconfig.yaml
+++ b/clusters/platform/clusterbook-providerconfig.yaml
@@ -1,0 +1,32 @@
+---
+# Seeds the cluster-scoped ClusterbookProviderConfig 'default' that points the
+# clusterbook-operator (deployed by the argocd-platform bundle) at the infra
+# cluster's clusterbook backend. Parameterized base lives in flux-apps; the
+# env-specific apiURL is supplied here via postBuild.substitute.
+apiVersion: kustomize.toolkit.fluxcd.io/v1
+kind: Kustomization
+metadata:
+  labels:
+    app.kubernetes.io/managed-by: flux
+    kustomization.stuttgart-things.com/type: cicd
+  name: clusterbook-providerconfig
+  namespace: flux-system
+spec:
+  interval: 1h
+  retryInterval: 1m
+  timeout: 5m
+  dependsOn:
+    - name: argocd-platform-clusterbook-operator
+  sourceRef:
+    kind: GitRepository
+    name: flux-apps
+  path: ./apps/clusterbook-operator/providerconfig
+  prune: true
+  wait: true
+  postBuild:
+    substitute:
+      CLUSTERBOOK_PROVIDERCONFIG_NAME: default
+      CLUSTERBOOK_API_URL: https://clusterbook.infra.sthings.lab
+      # Keep false if the infra clusterbook CA is in the operator's trust
+      # bundle; flip to "true" if the operator logs x509 verification errors.
+      CLUSTERBOOK_INSECURE_SKIP_VERIFY: "false"


### PR DESCRIPTION
## Seed clusterbook ProviderConfig (parameterized)

Wires the platform's `clusterbook-operator` (deployed by the argocd-platform bundle) to the infra cluster's clusterbook backend, using the parameterized base added in flux PR #162.

### File
- `clusters/platform/clusterbook-providerconfig.yaml` — a Flux `Kustomization` → `./apps/clusterbook-operator/providerconfig` (flux-apps), `dependsOn: argocd-platform-clusterbook-operator` (so the CRD exists first), with:
  ```yaml
  CLUSTERBOOK_PROVIDERCONFIG_NAME: default
  CLUSTERBOOK_API_URL: https://clusterbook.infra.sthings.lab
  CLUSTERBOOK_INSECURE_SKIP_VERIFY: "false"
  ```

Renders the cluster-scoped `ClusterbookProviderConfig/default` — which satisfies `providerConfigRef: default` on any `ClusterbookCluster` (e.g. `philly`).

### TLS note
`insecureSkipVerify: false` → the operator verifies `clusterbook.infra.sthings.lab` against its mounted `cluster-trust-bundle`. If the infra clusterbook CA isn't trusted by the platform, the operator will log x509 errors — flip the var to `"true"` (one-line change here) or add the infra CA to trust-manager.

### After merge
```bash
flux reconcile source git flux-apps -n flux-system
flux reconcile kustomization flux-system --with-source
flux get kustomization clusterbook-providerconfig -n flux-system        # True
kubectl get clusterbookproviderconfig default -o yaml                    # apiURL set
kubectl -n clusterbook-system logs deploy/clusterbook-operator | grep -i 'x509\|tls' || echo "no TLS errors"
```

https://claude.ai/code/session_014x4LVcwkrq73KDcKWLb8Wa

---
_Generated by [Claude Code](https://claude.ai/code/session_014x4LVcwkrq73KDcKWLb8Wa)_