### PR TITLE
feat(platform): add backstage developer portal

### DIFF
--- a/clusters/platform/apps/backstage-prereqs.yaml
+++ b/clusters/platform/apps/backstage-prereqs.yaml
@@ -1,0 +1,39 @@
+---
+# Prerequisites the backstage app itself doesn't create — applied by the
+# flux-system sync before the backstage Kustomization reconciles.
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: backstage
+  labels:
+    toolkit.fluxcd.io/tenant: sthings-team
+---
+# imageTag is passed via ConfigMap (not Flux substitution) so Helm keeps it a
+# string; consumed by release.yaml valuesFrom -> backstage.image.tag.
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: backstage-helm-overrides
+  namespace: backstage
+data:
+  imageTag: "v1.4.0"
+---
+# Catalog locations (sthings-harvester instance). Must contain the User
+# entities GitHub sign-in (usernameMatchingUserEntityName) resolves against.
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: backstage-catalog-config
+  namespace: backstage
+data:
+  app-config.catalog.yaml: |
+    catalog:
+      locations:
+        - type: url
+          target: https://github.com/stuttgart-things/backstage-resources/blob/main/org/sthings-harvester/org.yaml
+          rules:
+            - allow: [User, Group]
+        - type: url
+          target: https://github.com/stuttgart-things/backstage-resources/blob/main/services/sthings-harvester/catalog-index.yaml
+          rules:
+            - allow: [Component, Location, System, API, Resource, Template]

--- a/clusters/platform/apps/backstage-secrets-subst.enc.yaml
+++ b/clusters/platform/apps/backstage-secrets-subst.enc.yaml
@@ -1,0 +1,31 @@
+apiVersion: ENC[AES256_GCM,data:wo8=,iv:bezMC15kX63POx+AHTfwt+TDHI4oFLH3Nx1/OPrhUik=,tag:KAV5S0F0gMvsPfc6qvE/qQ==,type:str]
+kind: ENC[AES256_GCM,data:1/vsWdKW,iv:gM2miCOo3zifAfSaq0eRUcI9WVf3dfLlnLLU2WcBFvg=,tag:1UsmKEEP7XJwZf863BBqGQ==,type:str]
+metadata:
+    name: ENC[AES256_GCM,data:olIidnXdo5g8X1/z5aAlzRdpbCX3APM=,iv:3e2rM4+JPSmsl81fdzTWkJV1dlqXB6HdURViKCRNgdE=,tag:4ofObJ5QRkcUiwrxR0x2Sg==,type:str]
+    namespace: ENC[AES256_GCM,data:TtR3zQWtMlC86zI=,iv:Z4b529b1D/epuHjJZAe7IiXZYS5Mm7pg7yqcna+36BI=,tag:Cn/XucY+SFJFNRBHcN51wg==,type:str]
+type: ENC[AES256_GCM,data:znvZv9qY,iv:bcxoi/j1+iVdpeNV+1n8jTCEK/ms62J86x9X8b6UguU=,tag:mBHCf/Mwmx094SCUMB9fwA==,type:str]
+stringData:
+    BACKSTAGE_GITHUB_TOKEN: ENC[AES256_GCM,data:VRZjNClMMTKuD67x1/hLyoDO+pGZhUkfi5za6UnReD4zbZsU6L6kpQ==,iv:E7wSHr9ab0dBC4xOvh3fQNiMhAlx9d61ZTG6fHENHIA=,tag:USE4MtYR6h0gvlpl/6JSfQ==,type:str]
+    BACKSTAGE_GITHUB_CLIENT_ID: ENC[AES256_GCM,data:kkmNStpK2lZ6zeFffrwrvUFiiAA=,iv:mBecWiCz/vHl+yyQxkSjqCYB5T89C7bdwtOpZ7Na2G0=,tag:rDBLUpS80SZSyUiqq5Ld1g==,type:str]
+    BACKSTAGE_GITHUB_CLIENT_SECRET: ENC[AES256_GCM,data:epFCdQuAbLa2f4ZG3g34V/cbncKNYkO5yP+elK1Y7TOerAbC0Mcjdg==,iv:tMFAWuyyCmy2s40/EFQ6ZOmyuMr2V92pQWAMpEdnwnI=,tag:DqnzIY44rKBI3lwOcmBH/A==,type:str]
+    BACKSTAGE_BACKEND_SECRET: ENC[AES256_GCM,data:MRKfP1AQTRCaIy4qZPzjzxevLWQsZYYmiJXmksYNWhjV7ckMb0tTA0z2n+AW,iv:O+Bo+HCRbtq1Pc2TTKryorTdh119sScQ4XljT3gjJaQ=,tag:FLgD+2qPGOj1ouFAqWNGBw==,type:str]
+    BACKSTAGE_POSTGRESQL_PASSWORD: ENC[AES256_GCM,data:09q8bItcKlo=,iv:ehCLnL9sM374rFFHBToHDuUEbfpMR5OYeDqxQVJpIiw=,tag:EfoPjEn+BuANEa/JYvEGQw==,type:str]
+    BACKSTAGE_EXTERNAL_ACCESS_TOKEN: ENC[AES256_GCM,data:t4hCRMEzWFyt7Yk1bCGvvJTfxQPoJQKHxH/pZ3Tm4jg=,iv:gGU7G344k6+tL9dFw7RVxRNhxoEG0c4pU8W6Q2fKX40=,tag:gdZsJo/0PyrhNkAgvrMnjw==,type:str]
+    BACKSTAGE_ZITADEL_ISSUER: ENC[AES256_GCM,data:uimhoc1DYE1HdUUkdgxvAy0XR8eaSGI80V1fg/GjxQHEFvcQHwSDCngNR3aUBIrgcHWm5LFHywib,iv:EQ1uZo6SoGp6s9jEXFXJ2Hk9FmPTV0AGUT7W+4Qlznk=,tag:EFX+xjAyFqje93rWcfO9MQ==,type:str]
+    BACKSTAGE_ZITADEL_CLIENT_ID: ENC[AES256_GCM,data:bB4TPKnwff2drPjGDciUscHH,iv:fjST6w2a9cocD7kyEPAg+oQW4vNOWt11GwtF1O0Ty0s=,tag:vvw2/3rcIy2q+EONzr+hww==,type:str]
+    BACKSTAGE_ZITADEL_CLIENT_SECRET: ENC[AES256_GCM,data:zUjxxj6qs3kokMq9H1tytGJxylMwsUK/zr3p+0qAwXQyaORHO8gxfq82JfYg74CHFjDzoTNup5LPxAKK2l8CKg==,iv:RQ0E6QmsaDFZW83w68TmI+g/D2iY0E8ryMd0aIVmW6E=,tag:0x6oS9HJFCAK3rp+gN7FDw==,type:str]
+sops:
+    age:
+        - recipient: age19vgzvmpt9tdlcsu8rzaacj397yz8gguz38nsmuy6eeelt5vjsyms542xtm
+          enc: |
+            -----BEGIN AGE ENCRYPTED FILE-----
+            YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSBtYjhCYk5FYXNhNm9TYlpU
+            b0dnbUNMSkxPeVNsY0FJSFBmT1hlQWppQ2hVCjUra0xzcGhJdWR5MFNxNkk5Rldh
+            aW11cnNpZ3lqNThYcUtVLzNoV2NOV3cKLS0tIGpmWFRvaGVNQ1dMUHJFbU5NUDhx
+            VkgybThXMkQ1S3hUcXQyNzhlTDE0ZkkK+I3NJoDHiJ/6+dHkdD6yJZnce9hFTw6A
+            KizjaFTZ3AFPRcq4i6Uc5yQ5DqHwz5TROiWyZC6Fprlv/jUUxwMuXw==
+            -----END AGE ENCRYPTED FILE-----
+    lastmodified: "2026-06-05T13:36:56Z"
+    mac: ENC[AES256_GCM,data:5doq+RbS4easZMHDkTiz7Eax4tDhN/l2w22HomHNR3U+KFNHntv+imi0oLvcNMOtIxPMY9Jpu6nNNh1sXGRNRKo03dWWEtc2plngl2yNKK0wLhs/Ob3r07cysJA4kZNhd3qzJWQZSaOJp9D0lAZSVC/rSXfGO+dFgNdIq5VMaUY=,iv:GiQkvBTkuAUNq9uqKtthZuWGzrwgWLFDsUr5PwTHUKI=,tag:kiwUuVl81cJoSWJnhoIErA==,type:str]
+    unencrypted_suffix: _unencrypted
+    version: 3.12.1

--- a/clusters/platform/apps/backstage.yaml
+++ b/clusters/platform/apps/backstage.yaml
@@ -1,0 +1,35 @@
+---
+apiVersion: kustomize.toolkit.fluxcd.io/v1
+kind: Kustomization
+metadata:
+  labels:
+    app.kubernetes.io/managed-by: flux
+    kustomization.stuttgart-things.com/type: app
+  name: backstage
+  namespace: flux-system
+spec:
+  interval: 1h
+  retryInterval: 1m
+  timeout: 10m
+  sourceRef:
+    kind: GitRepository
+    name: flux-apps
+  path: ./apps/backstage
+  prune: true
+  wait: true
+  postBuild:
+    substitute:
+      BACKSTAGE_NAMESPACE: backstage
+      BACKSTAGE_VERSION: "2.6.3"
+      BACKSTAGE_IMAGE_REGISTRY: ghcr.io
+      BACKSTAGE_IMAGE_REPOSITORY: stuttgart-things/sthings-backstage
+      BACKSTAGE_STORAGE_CLASS: local-path
+      BACKSTAGE_REPLICAS: "1"
+      BACKSTAGE_APP_TITLE: Stuttgart Things Backstage
+      BACKSTAGE_ORGANIZATION_NAME: stuttgart-things
+      DOMAIN: platform.sthings.lab
+      GATEWAY_NAME: platform-sthings-gateway
+      GATEWAY_NAMESPACE: default
+    substituteFrom:
+      - kind: Secret
+        name: backstage-secrets-subst


### PR DESCRIPTION
## Add Backstage (developer portal)

Deploys Backstage on the platform cluster via the flux `apps/backstage` app, adapted for harvester.

### Files (`clusters/platform/apps/`)
- **`backstage.yaml`** — Flux `Kustomization` → `./apps/backstage`. `BACKSTAGE_STORAGE_CLASS=local-path`, `DOMAIN=platform.sthings.lab`, gateway `platform-sthings-gateway`/`default`, `substituteFrom: backstage-secrets-subst`. Namespace `backstage`.
- **`backstage-prereqs.yaml`** — namespace `backstage` + `backstage-helm-overrides` (**`imageTag: "v1.4.0"`**, pinned) + `backstage-catalog-config` (the **sthings-harvester** catalog: `org/sthings-harvester/org.yaml` + `services/sthings-harvester/catalog-index.yaml`).
- **`backstage-secrets-subst.enc.yaml`** — SOPS source secret (the `BACKSTAGE_*` substitution vars incl. GitHub OAuth, backend secret, postgres password, Zitadel). Encrypted to the cluster age key.

### Config decisions
| Setting | Value |
|---|---|
| Hostname | `backstage.platform.sthings.lab` (matches your GitHub OAuth callback) |
| Namespace | `backstage` |
| Storage | `local-path` |
| Image | `v1.4.0` (pinned) |
| Catalog | sthings-harvester instance |

### After merge
```bash
flux reconcile kustomization flux-system --with-source
flux get hr -n backstage                 # backstage-configuration, backstage-deployment
kubectl -n backstage get pods            # backstage + postgresql
flux reconcile hr backstage-deployment -n backstage --force   # if first-install --wait stalls
```
Then it's at **`https://backstage.platform.sthings.lab`** (GitHub sign-in resolves against the `User` entities in the sthings-harvester catalog).

### Notes
- **Trust bundle not included** (kept minimal). GitHub OAuth + catalog use github.com (public TLS), so it starts fine. If you later use the internal claim-machinery proxy over Vault-PKI HTTPS, add the documented `NODE_EXTRA_CA_CERTS` + `cluster-trust-bundle` patch — I can do that follow-up.
- Watch postgres scheduling — if its default request doesn't fit, I'll add a `resourcesPreset` patch like harbor.

https://claude.ai/code/session_014x4LVcwkrq73KDcKWLb8Wa

---
_Generated by [Claude Code](https://claude.ai/code/session_014x4LVcwkrq73KDcKWLb8Wa)_