### PR TITLE
fix(platform): pin backstage image to v1.3.4

### DIFF
--- a/clusters/platform/apps/backstage-prereqs.yaml
+++ b/clusters/platform/apps/backstage-prereqs.yaml
@@ -16,7 +16,7 @@ metadata:
   name: backstage-helm-overrides
   namespace: backstage
 data:
-  imageTag: "v1.4.0"
+  imageTag: "v1.3.4"
 ---
 # Catalog locations (sthings-harvester instance). Must contain the User
 # entities GitHub sign-in (usernameMatchingUserEntityName) resolves against.


### PR DESCRIPTION
## Pin Backstage image to v1.3.4

`v1.4.0`'s frontend crashes after login with `NotImplementedError: No implementation available for apiRef{core.toast}` → white page. Pin to **`v1.3.4`** until the upstream `sthings-backstage` fix lands.

The DB is on `pg` now (flux #165), so no `better-sqlite3` native-binding dependency on any tag.

### After merge
```bash
flux reconcile kustomization flux-system --with-source      # picks up the new imageTag
flux reconcile hr backstage-deployment -n backstage --force # helm valuesFrom re-reads the ConfigMap
kubectl -n backstage rollout restart deploy/backstage-deployment
kubectl -n backstage get pods -w
```
Then `https://backstage.platform.sthings.lab` should render.

https://claude.ai/code/session_014x4LVcwkrq73KDcKWLb8Wa

---
_Generated by [Claude Code](https://claude.ai/code/session_014x4LVcwkrq73KDcKWLb8Wa)_