### PR TITLE
test: add large VM + dagger RKE2 provisioning

### DIFF
--- a/tests/rke2-cluster/README.md
+++ b/tests/rke2-cluster/README.md
@@ -1,0 +1,104 @@
+# RKE2 CLUSTER ON HARVESTER (single large VM)
+
+Provision a single **large** Harvester VM (from the `u26-dev` image) and turn it
+into a single-node RKE2 cluster via the stuttgart-things Ansible blueprints
+(run through Dagger).
+
+The flow is:
+
+1. `kubectl apply` the VM manifest on Harvester.
+2. Wait for the VM to be `Running` and grab its DHCP IP.
+3. Write that IP into the Ansible inventory (`inv`).
+4. Run the Dagger Ansible provisioning to install RKE2.
+
+## Machine spec
+
+| Field | Value |
+|---|---|
+| Name | `rke2-test` |
+| Image | `default/u26-dev` (Ubuntu 26 dev base, SSH-ready `sthings` user) |
+| vCPU | 8 cores |
+| Memory | 16 Gi |
+| Root disk | 60 Gi (Longhorn, image-backed) |
+| Network | `default/vms` NAD (bridged onto `mgmt-br`, DHCP from DD-WRT) |
+
+See [`vm-rke2.yaml`](./vm-rke2.yaml).
+
+## Prerequisites
+
+- `KUBECONFIG` pointing at the Harvester cluster (`harvester.sthings.lab`).
+- The `u26-dev` image present in the `default` namespace
+  (see [../install.md](../install.md)).
+- `dagger`, `kubectl` and `jq` on the workstation.
+- SSH credentials for the `sthings` user exported as env vars:
+  ```bash
+  export SSH_USER=sthings
+  export SSH_PASSWORD=<password>   # or use the key baked into the image
+  ```
+
+## 1. Apply the VM
+
+```bash
+kubectl apply -f vm-rke2.yaml
+```
+
+## 2. Wait for the VM and get its IP
+
+```bash
+# Wait until the VM reports Running
+kubectl wait --for=jsonpath='{.status.printableStatus}'=Running \
+  vm/rke2-test -n default --timeout=300s
+
+# Wait until the guest agent reports an IP, then capture it
+until VM_IP=$(kubectl get vmi rke2-test -n default \
+  -o jsonpath='{.status.interfaces[0].ipAddress}' 2>/dev/null) && [ -n "$VM_IP" ]; do
+  echo "waiting for VM IP..."; sleep 5
+done
+echo "VM IP: ${VM_IP}"
+```
+
+## 3. Write the IP into the inventory
+
+```bash
+sed -i "s/VM_IP_PLACEHOLDER/${VM_IP}/" inv
+cat inv
+```
+
+## 4. Provision RKE2 with Dagger
+
+```bash
+dagger call -m github.com/stuttgart-things/blueprints/vm@v1.56.0 execute-ansible \
+--src "." \
+--playbooks ./plays.yaml \
+--inventory ./inv \
+--ssh-user=env:SSH_USER \
+--ssh-password=env:SSH_PASSWORD \
+--requirements-data requirements-data.yaml \
+--parameters-file vars.yaml \
+--progress plain -vv
+```
+
+The kubeconfig is fetched to `/tmp/kubeconfig` (see `fetched_kubeconfig_path`
+in [`vars.yaml`](./vars.yaml)).
+
+## Configuration
+
+- **Provisioning Type**: rke2-cluster
+- **Cluster Name**: rke2
+- **Kubernetes Version**: 1.35.1
+- **Cluster Setup**: singlenode
+- **CNI**: Cilium (kube-proxy disabled)
+
+## Playbooks
+
+See [plays.yaml](./plays.yaml) for the playbooks that will be executed.
+
+## Variables
+
+See [vars.yaml](./vars.yaml) for all configuration variables.
+
+## Teardown
+
+```bash
+kubectl delete -f vm-rke2.yaml
+```

--- a/tests/rke2-cluster/inv
+++ b/tests/rke2-cluster/inv
@@ -1,0 +1,5 @@
+
+[initial_master_node]
+VM_IP_PLACEHOLDER
+[additional_master_nodes]
+[workers]

--- a/tests/rke2-cluster/plays.yaml
+++ b/tests/rke2-cluster/plays.yaml
@@ -1,0 +1,7 @@
+---
+- name: Base setup
+  ansible.builtin.import_playbook: sthings.baseos.setup
+  when: execute_baseos | default(true) | bool
+
+- name: Deploy and configure RKE2
+  ansible.builtin.import_playbook: sthings.rke.rke2_cluster

--- a/tests/rke2-cluster/requirements-data.yaml
+++ b/tests/rke2-cluster/requirements-data.yaml
@@ -11,6 +11,6 @@ gitCollections:
   ansible.netcommon: 8.4.0
 
 artifactCollections:
-  - https://github.com/stuttgart-things/ansible/releases/download/sthings-rke-26.3.607.tar.gz/sthings-rke-26.3.607.tar.gz
-  - https://github.com/stuttgart-things/ansible/releases/download/sthings-container-26.4.1164.tar.gz/sthings-container-26.4.1164.tar.gz
-  - https://github.com/stuttgart-things/ansible/releases/download/sthings-baseos-26.4.1160.tar.gz/sthings-baseos-26.4.1160.tar.gz
+  - https://github.com/stuttgart-things/ansible/releases/download/sthings-rke-26.1.776.tar.gz/sthings-rke-26.1.776.tar.gz
+  - https://github.com/stuttgart-things/ansible/releases/download/sthings-container-26.3.948.tar.gz/sthings-container-26.3.948.tar.gz
+  - https://github.com/stuttgart-things/ansible/releases/download/sthings-baseos-26.3.1037.tar.gz/sthings-baseos-26.3.1037.tar.gz

--- a/tests/rke2-cluster/requirements-data.yaml
+++ b/tests/rke2-cluster/requirements-data.yaml
@@ -1,0 +1,16 @@
+---
+gitCollections:
+  community.crypto: 3.1.0
+  community.general: 12.3.0
+  ansible.posix: 2.1.0
+  kubernetes.core: 6.2.0
+  community.docker: 5.0.5
+  community.vmware: 5.8.0
+  awx.awx: 24.6.1
+  community.hashi_vault: 7.0.0
+  ansible.netcommon: 8.4.0
+
+artifactCollections:
+  - https://github.com/stuttgart-things/ansible/releases/download/sthings-rke-26.3.607.tar.gz/sthings-rke-26.3.607.tar.gz
+  - https://github.com/stuttgart-things/ansible/releases/download/sthings-container-26.4.1164.tar.gz/sthings-container-26.4.1164.tar.gz
+  - https://github.com/stuttgart-things/ansible/releases/download/sthings-baseos-26.4.1160.tar.gz/sthings-baseos-26.4.1160.tar.gz

--- a/tests/rke2-cluster/vars.yaml
+++ b/tests/rke2-cluster/vars.yaml
@@ -1,0 +1,19 @@
+---
+# BASE_OS
+execute_baseos: true
+
+# RKE2 CLUSTER
+rke_state: present
+rke2_k8s_version: 1.35.1
+cluster_setup: singlenode
+rke2_release_kind: rke2r1
+rke2_cni: none
+install_cilium: true
+rke2_airgapped_installation: true
+prepare_rancher_ha_nodes: false
+disableKubeProxy: true
+cluster_name: rke2
+fetched_kubeconfig_path: /tmp/kubeconfig
+install_helm_diff: false
+
+registry_mirror_url: https://registry-1.docker.io

--- a/tests/rke2-cluster/vm-rke2.yaml
+++ b/tests/rke2-cluster/vm-rke2.yaml
@@ -1,0 +1,70 @@
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: rke2-test-root
+  namespace: default
+  annotations:
+    harvesterhci.io/imageId: "default/u26-dev"
+spec:
+  accessModes: ["ReadWriteMany"]
+  volumeMode: Block
+  storageClassName: lh-7f7c570a-a326-4232-b291-3f2a946aeadf
+  resources:
+    requests:
+      storage: 60Gi
+---
+apiVersion: kubevirt.io/v1
+kind: VirtualMachine
+metadata:
+  name: rke2-test
+  namespace: default
+  labels:
+    harvesterhci.io/creator: harvester
+    harvesterhci.io/os: linux
+spec:
+  runStrategy: RerunOnFailure
+  template:
+    metadata:
+      labels:
+        harvesterhci.io/vmName: rke2-test
+    spec:
+      domain:
+        cpu: { cores: 8, sockets: 1, threads: 1 }
+        memory: { guest: 16Gi }
+        resources:
+          requests: { cpu: "4", memory: 16Gi }
+        machine: { type: q35 }
+        devices:
+          disks:
+            - name: rootdisk
+              bootOrder: 1
+              disk: { bus: virtio }
+            - name: cloudinitdisk
+              disk: { bus: virtio }
+          interfaces:
+            - name: nic-0
+              bridge: {}
+              model: virtio
+      networks:
+        - name: nic-0
+          multus:
+            networkName: default/vms
+      volumes:
+        - name: rootdisk
+          persistentVolumeClaim:
+            claimName: rke2-test-root
+        - name: cloudinitdisk
+          cloudInitNoCloud:
+            userData: |
+              #cloud-config
+              hostname: rke2-test
+              package_update: true
+              packages:
+                - qemu-guest-agent
+              runcmd:
+                - systemctl enable --now qemu-guest-agent
+            networkData: |
+              version: 2
+              ethernets:
+                eth0:
+                  dhcp4: true


### PR DESCRIPTION
## What

Adds `tests/rke2-cluster/` — a single **large** Harvester VM that gets turned into a single-node RKE2 cluster via the stuttgart-things Ansible blueprints (run through Dagger).

| File | Purpose |
|---|---|
| `vm-rke2.yaml` | Large VM manifest — same Harvester, same image (`default/u26-dev`), same Longhorn storage class & `default/vms` network as `vm-u26.yaml`, scaled to **8 vCPU / 16 Gi RAM / 60 Gi disk** |
| `plays.yaml` | Ansible playbooks (baseos setup + `sthings.rke.rke2_cluster`) |
| `inv` | Inventory with a `VM_IP_PLACEHOLDER` filled in after the VM gets its IP |
| `vars.yaml` | RKE2 vars — `singlenode`, k8s 1.35.1, Cilium CNI, kube-proxy disabled |
| `requirements-data.yaml` | Ansible collection/artifact requirements |
| `README.md` | Full workflow |

## Workflow

1. `kubectl apply -f vm-rke2.yaml`
2. Wait for the VM to be `Running` and capture its DHCP IP
3. `sed` the IP into `inv`
4. Run Dagger `execute-ansible` to install RKE2

## Notes

- Configured as a **single large node** (not the 4-node HA reference) since the ask was for one large machine. Switching to multi-node HA is a small `vars.yaml` change.
- `execute_baseos: true` (fresh VM from image).
- No kubeconfig-to-git export; kubeconfig lands at `/tmp/kubeconfig`.

https://claude.ai/code/session_01SbrEgcgTF3YwqwtAEpXSoM

---
_Generated by [Claude Code](https://claude.ai/code/session_01SbrEgcgTF3YwqwtAEpXSoM)_