### PR TITLE
deploy(platform): bump backstage imageTag v1.3.4 -> v1.4.6

### DIFF
--- a/clusters/platform/apps/backstage-prereqs.yaml
+++ b/clusters/platform/apps/backstage-prereqs.yaml
@@ -16,7 +16,7 @@ metadata:
   name: backstage-helm-overrides
   namespace: backstage
 data:
-  imageTag: "v1.3.4"
+  imageTag: "v1.4.6"
 ---
 # Catalog locations (sthings-harvester instance). Must contain the User
 # entities GitHub sign-in (usernameMatchingUserEntityName) resolves against.


### PR DESCRIPTION
Unpins from the `v1.3.4` workaround (#87). v1.4.6 fixes the `core.toast` white-screen after login (stuttgart-things/sthings-backstage#95) and includes the better-sqlite3 native binding + mkdocs (techdocs), so it boots and renders docs regardless of this cluster's db/techdocs config. Verified on the labul cluster (1/1 Ready, login + techdocs working).

The effective image tag is this ConfigMap `imageTag` (HelmRelease valuesFrom), not `backstage.yaml` — which carries no tag field.

🤖 Generated with [Claude Code](https://claude.com/claude-code)