### PR TITLE
packer: force HTTP/1.1 on Harvester image upload to avoid curl 92

### DIFF
--- a/packer/opensuse-leap/upload.sh
+++ b/packer/opensuse-leap/upload.sh
@@ -70,7 +70,9 @@ yq -j '.metadata.name = "'"${IMAGE_NAME}"'" | .spec.displayName = "'"${IMAGE_NAM
     "https://${HARVESTER_VIP}/v1/harvester/harvesterhci.io.virtualmachineimages/${NAMESPACE}" &> /dev/null
 
 echo "Uploading image ${IMAGE_FILE} (${IMAGE_SIZE} bytes)..."
-curl -sk -X POST \
+# Force HTTP/1.1: large multipart uploads over HTTP/2 fail with curl exit 92
+# (CURLE_HTTP2_STREAM / framing-layer stream error) against Harvester.
+curl -sk -X POST --http1.1 \
   -H "Authorization: Bearer ${TOKEN}" \
   -F "chunk=@${IMAGE_FILE}" \
   "https://${HARVESTER_VIP}/v1/harvester/harvesterhci.io.virtualmachineimages/${NAMESPACE}/${IMAGE_NAME}?action=upload&size=${IMAGE_SIZE}"

--- a/packer/rocky/upload.sh
+++ b/packer/rocky/upload.sh
@@ -70,7 +70,9 @@ yq -j '.metadata.name = "'"${IMAGE_NAME}"'" | .spec.displayName = "'"${IMAGE_NAM
     "https://${HARVESTER_VIP}/v1/harvester/harvesterhci.io.virtualmachineimages/${NAMESPACE}" &> /dev/null
 
 echo "Uploading image ${IMAGE_FILE} (${IMAGE_SIZE} bytes)..."
-curl -sk -X POST \
+# Force HTTP/1.1: large multipart uploads over HTTP/2 fail with curl exit 92
+# (CURLE_HTTP2_STREAM / framing-layer stream error) against Harvester.
+curl -sk -X POST --http1.1 \
   -H "Authorization: Bearer ${TOKEN}" \
   -F "chunk=@${IMAGE_FILE}" \
   "https://${HARVESTER_VIP}/v1/harvester/harvesterhci.io.virtualmachineimages/${NAMESPACE}/${IMAGE_NAME}?action=upload&size=${IMAGE_SIZE}"

--- a/packer/ubuntu26/upload.sh
+++ b/packer/ubuntu26/upload.sh
@@ -70,7 +70,9 @@ yq -j '.metadata.name = "'"${IMAGE_NAME}"'" | .spec.displayName = "'"${IMAGE_NAM
     "https://${HARVESTER_VIP}/v1/harvester/harvesterhci.io.virtualmachineimages/${NAMESPACE}" &> /dev/null
 
 echo "Uploading image ${IMAGE_FILE} (${IMAGE_SIZE} bytes)..."
-curl -sk -X POST \
+# Force HTTP/1.1: large multipart uploads over HTTP/2 fail with curl exit 92
+# (CURLE_HTTP2_STREAM / framing-layer stream error) against Harvester.
+curl -sk -X POST --http1.1 \
   -H "Authorization: Bearer ${TOKEN}" \
   -F "chunk=@${IMAGE_FILE}" \
   "https://${HARVESTER_VIP}/v1/harvester/harvesterhci.io.virtualmachineimages/${NAMESPACE}/${IMAGE_NAME}?action=upload&size=${IMAGE_SIZE}"


### PR DESCRIPTION
## What
Pin the image-upload `curl` to `--http1.1` in `upload.sh` for `ubuntu26`, `rocky`, and `opensuse-leap`.

## Why
A `workflow_dispatch` build of `ubuntu26` succeeded through the full Packer build + cloud-init, but the final Harvester upload step failed with **curl exit 92** (`CURLE_HTTP2_STREAM` — "stream error in the HTTP/2 framing layer") right after starting the 1.6 GB multipart upload. The `VirtualMachineImage` object had already been created, so the image was left without its binary.

Large multipart uploads over HTTP/2 are a well-known trigger for curl 92; forcing HTTP/1.1 is the standard fix. All three templates share an identical `upload.sh`, so the flag is applied to each.

Discovered while validating the `package_upgrade` change (the build/cloud-init part passed cleanly — this failure was a pre-existing upload fragility, not related to that change).

🤖 Generated with [Claude Code](https://claude.com/claude-code)