### PR TITLE
feat(crossplane): switch harvester test to air-gapped k3s

### DIFF
--- a/tests/crossplane/README.md
+++ b/tests/crossplane/README.md
@@ -1,15 +1,16 @@
-# RKE2 CLUSTER ON HARVESTER (single large VM)
+# K3S CLUSTER ON HARVESTER (single large VM)
 
 Provision a single **large** Harvester VM (from the `u26-dev` image) and turn it
-into a single-node RKE2 cluster via the stuttgart-things Ansible blueprints
-(run through Dagger).
+into a single-node k3s cluster via the stuttgart-things Ansible blueprints
+(run through Dagger). Air-gapped: k3s + Cilium images are pre-loaded from the
+internal mirror and docker.io is pulled through a harbor mirror.
 
 The flow is:
 
 1. `kubectl apply` the VM manifest on Harvester.
 2. Wait for the VM to be `Running` and grab its DHCP IP.
 3. Write that IP into the Ansible inventory (`inv`).
-4. Run the Dagger Ansible provisioning to install RKE2.
+4. Run the Dagger Ansible provisioning to install k3s.
 
 ## Machine spec
 
@@ -22,7 +23,7 @@ The flow is:
 | Root disk | 60 Gi (Longhorn, image-backed) |
 | Network | `default/vms` NAD (bridged onto `mgmt-br`, DHCP from DD-WRT) |
 
-See [`vm-rke2.yaml`](./vm-rke2.yaml).
+See [`vm.yaml`](./vm.yaml).
 
 ## Prerequisites
 
@@ -39,7 +40,7 @@ See [`vm-rke2.yaml`](./vm-rke2.yaml).
 ## 1. Apply the VM
 
 ```bash
-kubectl apply -f vm-rke2.yaml
+kubectl apply -f vm.yaml
 ```
 
 ## 2. Wait for the VM and get its IP
@@ -64,7 +65,7 @@ sed -i "s/VM_IP_PLACEHOLDER/${VM_IP}/" inv
 cat inv
 ```
 
-## 4. Provision RKE2 with Dagger
+## 4. Provision k3s with Dagger
 
 ```bash
 dagger call -m github.com/stuttgart-things/blueprints/vm@v2.4.1 execute-ansible-encrypt-and-commit --src "." --playbooks ./plays.yaml --inventory ./inv --ssh-user=env:SSH_USER --ssh-password=env:SSH_PASSWORD --requirements-data requirements-data.yaml --parameters-file vars.yaml --git-repository "stuttgart-things/harvester" --git-branch main --git-commit-message "Add encrypted kubeconfig for k3s cluster infra" --git-destination-path "secrets" --git-token=env:GITHUB_TOKEN --export-paths "/tmp/crossplane.yaml" --age-public-key=env:AGE_PUB --progress plain -vv
@@ -75,11 +76,15 @@ in [`vars.yaml`](./vars.yaml)).
 
 ## Configuration
 
-- **Provisioning Type**: rke2-cluster
-- **Cluster Name**: rke2
-- **Kubernetes Version**: 1.35.1
+- **Provisioning Type**: k3s-cluster
+- **Cluster Name**: k3s
+- **Kubernetes Version**: 1.36.1+k3s1
 - **Cluster Setup**: singlenode
-- **CNI**: Cilium (kube-proxy disabled)
+- **CNI**: Cilium (kube-proxy replaced)
+- **Air-gapped images**: k3s + Cilium tars pre-loaded from
+  `artifacts.platform.sthings.lab` (`cilium_image_pull_policy: Never`)
+- **Registry mirror**: docker.io → `docker.harbor.platform.sthings.lab`
+  (fallback to upstream)
 
 ## Playbooks
 
@@ -92,5 +97,5 @@ See [vars.yaml](./vars.yaml) for all configuration variables.
 ## Teardown
 
 ```bash
-kubectl delete -f vm-rke2.yaml
+kubectl delete -f vm.yaml
 ```

--- a/tests/crossplane/plays.yaml
+++ b/tests/crossplane/plays.yaml
@@ -7,5 +7,5 @@
   ansible.builtin.import_playbook: sthings.baseos.setup
   when: execute_baseos | default(true) | bool
 
-- name: Deploy and configure RKE2
-  ansible.builtin.import_playbook: sthings.rke.rke2_cluster
+- name: Deploy and configure k3s
+  ansible.builtin.import_playbook: sthings.rke.k3s_cluster

--- a/tests/crossplane/requirements-data.yaml
+++ b/tests/crossplane/requirements-data.yaml
@@ -11,6 +11,6 @@ gitCollections:
   ansible.netcommon: 8.4.0
 
 artifactCollections:
-  - https://github.com/stuttgart-things/ansible/releases/download/sthings-rke-26.1.776.tar.gz/sthings-rke-26.1.776.tar.gz
+  - https://github.com/stuttgart-things/ansible/releases/download/sthings-rke-26.1.561.tar.gz/sthings-rke-26.1.561.tar.gz
   - https://github.com/stuttgart-things/ansible/releases/download/sthings-container-26.3.948.tar.gz/sthings-container-26.3.948.tar.gz
   - https://github.com/stuttgart-things/ansible/releases/download/sthings-baseos-26.3.1037.tar.gz/sthings-baseos-26.3.1037.tar.gz

--- a/tests/crossplane/vars.yaml
+++ b/tests/crossplane/vars.yaml
@@ -6,18 +6,42 @@ manage_filesystem: false
 vault_instances:
   - https://vault.infra.sthings.lab
 
-# RKE2 CLUSTER
-rke_state: present
-rke2_k8s_version: 1.35.1
+# K3S CLUSTER
+install_k3s: true
+k3s_state: present
+# NOTE: the k3s images tar below is version-specific — keep k3s_k8s_version /
+# k3s_release_kind matching the version the tar was built from.
+k3s_k8s_version: 1.36.1
+k3s_release_kind: k3s1
 cluster_setup: singlenode
-rke2_release_kind: rke2r1
-rke2_cni: none
 install_cilium: true
-rke2_airgapped_installation: true
 prepare_rancher_ha_nodes: false
-disableKubeProxy: true
-cluster_name: rke2
+cluster_name: k3s
 fetched_kubeconfig_path: /tmp/kubeconfig
 install_helm_diff: false
 
-registry_mirror_url: https://registry-1.docker.io
+# --- air-gapped k3s IMAGES from the harvester mirror (images-only) ----------
+# Pre-seeds the archive into /var/lib/rancher/k3s/agent/images/. The k3s binary
+# + install script still come from upstream unless k3s_airgapped_skip_download
+# is also set.
+k3s_airgapped_installation: true
+k3s_airgapped_image_url: "https://artifacts.platform.sthings.lab/images/k3s-airgap-images-amd64.tar.zst"
+
+# --- Cilium air-gapped IMAGES (pre-load tar + pin pull policy) ---------------
+# cilium-cli pulls from quay.io; this imports its images into containerd and
+# pins pullPolicy so the agent/operator/envoy start from the local store.
+cilium_airgapped_images: true
+cilium_airgapped_image_url: "https://artifacts.platform.sthings.lab/images/cilium-images.tar"
+cilium_image_pull_policy: Never
+
+# --- docker.io pull-through MIRROR -> harbor (with upstream fallback) --------
+k3s_registry_mirrors:
+  - name: "docker.io"
+    endpoints:
+      - "https://docker.harbor.platform.sthings.lab"
+      - "https://registry-1.docker.io"
+# harbor presents an internal/untrusted cert -> skip verification for that host.
+k3s_registry_configs:
+  "docker.harbor.platform.sthings.lab":
+    tls:
+      insecure_skip_verify: true


### PR DESCRIPTION
## What

Converts `tests/crossplane` from RKE2 to an air-gapped **k3s** cluster.

## Changes

- **plays.yaml** — `sthings.rke.rke2_cluster` → `sthings.rke.k3s_cluster`.
- **requirements-data.yaml** — rke collection pin `26.1.776` (non-existent) → **`26.1.561`** (pins deploy-configure-rke 2026.06.08-2, with the Cilium image-import `changed_when` fix).
- **vars.yaml** — RKE2 vars → k3s (1.36.1+k3s1); air-gapped k3s images + Cilium image tar from `artifacts.platform.sthings.lab` (`cilium_image_pull_policy: Never`); docker.io pull-through mirror → `docker.harbor.platform.sthings.lab` with `insecure_skip_verify` for the internal harbor cert.
- **README.md** — k3s wording; fixed stale `vm-rke2.yaml` → `vm.yaml` references.

The air-gapped k3s + Harbor mirror + Cilium archive flow was verified end-to-end on a clean node before this.

🤖 Generated with [Claude Code](https://claude.com/claude-code)