### PR TITLE
fix(crossplane): align kubeconfig export path

### DIFF
--- a/tests/crossplane/README.md
+++ b/tests/crossplane/README.md
@@ -68,10 +68,10 @@ cat inv
 ## 4. Provision k3s with Dagger
 
 ```bash
-dagger call -m github.com/stuttgart-things/blueprints/vm@v2.4.1 execute-ansible-encrypt-and-commit --src "." --playbooks ./plays.yaml --inventory ./inv --ssh-user=env:SSH_USER --ssh-password=env:SSH_PASSWORD --requirements-data requirements-data.yaml --parameters-file vars.yaml --git-repository "stuttgart-things/harvester" --git-branch main --git-commit-message "Add encrypted kubeconfig for k3s cluster infra" --git-destination-path "secrets" --git-token=env:GITHUB_TOKEN --export-paths "/tmp/crossplane.yaml" --age-public-key=env:AGE_PUB --progress plain -vv
+dagger call -m github.com/stuttgart-things/blueprints/vm@v2.4.1 execute-ansible-encrypt-and-commit --src "." --playbooks ./plays.yaml --inventory ./inv --ssh-user=env:SSH_USER --ssh-password=env:SSH_PASSWORD --requirements-data requirements-data.yaml --parameters-file vars.yaml --git-repository "stuttgart-things/harvester" --git-branch main --git-commit-message "Add encrypted kubeconfig for k3s cluster infra" --git-destination-path "secrets" --git-token=env:GITHUB_TOKEN --export-paths "/tmp/kubeconfig.yaml" --age-public-key=env:AGE_PUB --progress plain -vv
 ```
 
-The kubeconfig is fetched to `/tmp/kubeconfig` (see `fetched_kubeconfig_path`
+The kubeconfig is fetched to `/tmp/kubeconfig.yaml` (see `fetched_kubeconfig_path`
 in [`vars.yaml`](./vars.yaml)).
 
 ## Configuration

--- a/tests/crossplane/vars.yaml
+++ b/tests/crossplane/vars.yaml
@@ -17,7 +17,7 @@ cluster_setup: singlenode
 install_cilium: true
 prepare_rancher_ha_nodes: false
 cluster_name: k3s
-fetched_kubeconfig_path: /tmp/kubeconfig
+fetched_kubeconfig_path: /tmp/kubeconfig.yaml
 install_helm_diff: false
 
 # --- air-gapped k3s IMAGES from the harvester mirror (images-only) ----------


### PR DESCRIPTION
The air-gapped k3s deploy succeeds (k3s 1.36.1, Cilium agent/operator/envoy Running from the local image store, Harbor mirror), but the final `execute-ansible-encrypt-and-commit` export failed:

```
Error: stat /tmp/kubeconfig.yaml: no such file or directory
```

The role fetched the kubeconfig to `/tmp/kubeconfig` (`fetched_kubeconfig_path`) while dagger's `--export-paths` expected `/tmp/kubeconfig.yaml`. This aligns both (and the README prose) on `/tmp/kubeconfig.yaml` so the encrypted kubeconfig commit completes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)