### PR TITLE
feat: point platform argocd-platform at sthings-lab overlay + add git-repos

### DIFF
--- a/clusters/platform/apps/argocd-platform.yaml
+++ b/clusters/platform/apps/argocd-platform.yaml
@@ -1,12 +1,14 @@
 ---
-# argocd-platform bundle (base scope): stands up Argo CD (same cicd/argo-cd
-# install as before) + clusterbook-operator + argocd-config (AppProjects +
-# cluster-generator ApplicationSet), all dependsOn-ordered. Replaces the
-# standalone clusters/platform/apps/argo-cd.yaml Kustomization.
+# argocd-platform bundle (sthings-lab overlay): stands up Argo CD (same
+# cicd/argo-cd install as before) + clusterbook-operator + argocd-config
+# (AppProjects + cluster-generator ApplicationSet), all dependsOn-ordered.
+# Replaces the standalone clusters/platform/apps/argo-cd.yaml Kustomization.
 #
-# Platforms are opt-in: point at ./cicd/argocd-platform/overlays/full (or a
-# trimmed overlay) and add the argocd-catalog GitRepository source to enable
-# catalog platform stacks. Base needs only flux-apps + argocd-secrets.
+# Platforms are opt-in: this points at the sthings-lab overlay, which enables
+# the network, cicd, security, storage and kind catalog platforms. The
+# overlay's component list is the on/off switch (in the flux repo). Requires
+# the argocd-catalog GitRepository source (see ../git-repos.yaml) plus
+# flux-apps + argocd-secrets.
 apiVersion: kustomize.toolkit.fluxcd.io/v1
 kind: Kustomization
 metadata:
@@ -22,13 +24,14 @@ spec:
   sourceRef:
     kind: GitRepository
     name: flux-apps
-  path: ./cicd/argocd-platform/base
+  path: ./cicd/argocd-platform/overlays/sthings-lab
   prune: true
   wait: true
   postBuild:
     substitute:
       BUNDLE_NAME: argocd-platform
       FLUX_SOURCE: flux-apps
+      ARGOCD_CATALOG_SOURCE: argocd-catalog
       ARGO_CD_VERSION: "9.4.15"
       ARGO_CD_NAMESPACE: argocd
       ARGO_CD_INGRESS_ENABLED: "false"

--- a/clusters/platform/git-repos.yaml
+++ b/clusters/platform/git-repos.yaml
@@ -1,0 +1,37 @@
+---
+# Git sources for the platform cluster. flux-infra/flux-apps were previously
+# bootstrapped by hand (see README); committing them here brings them under
+# GitOps, matching clusters/infra and clusters/xplane. argocd-catalog is the
+# source consumed by the argocd-platform catalog components (./platforms/*).
+apiVersion: source.toolkit.fluxcd.io/v1
+kind: GitRepository
+metadata:
+  name: flux-infra
+  namespace: flux-system
+spec:
+  interval: 1m0s
+  ref:
+    branch: main
+  url: https://github.com/stuttgart-things/flux.git
+---
+apiVersion: source.toolkit.fluxcd.io/v1
+kind: GitRepository
+metadata:
+  name: flux-apps
+  namespace: flux-system
+spec:
+  interval: 1m0s
+  ref:
+    branch: main
+  url: https://github.com/stuttgart-things/flux.git
+---
+apiVersion: source.toolkit.fluxcd.io/v1
+kind: GitRepository
+metadata:
+  name: argocd-catalog
+  namespace: flux-system
+spec:
+  interval: 1m0s
+  ref:
+    branch: main
+  url: https://github.com/stuttgart-things/argocd.git


### PR DESCRIPTION
## What

Wires the platform cluster to consume the new `argocd-platform` catalog overlays (merged in stuttgart-things/flux#170):

- **`clusters/platform/apps/argocd-platform.yaml`** — repoint `path:` from `./cicd/argocd-platform/base` to `./cicd/argocd-platform/overlays/sthings-lab` (enables network, cicd, security, storage, kind) and add `ARGOCD_CATALOG_SOURCE: argocd-catalog`. All other substitutions unchanged.
- **`clusters/platform/git-repos.yaml`** (new) — define `flux-infra`, `flux-apps`, and the new `argocd-catalog` GitRepository (`https://github.com/stuttgart-things/argocd.git`, `branch: main`), matching the committed `git-repos.yaml` convention in `clusters/infra` and `clusters/xplane` and bringing the previously hand-bootstrapped sources under GitOps.

## Effect

The `FluxInstance` recursively syncs `clusters/platform`, so on reconcile the cluster gains `argocd-platform-platform-{network,cicd,security,storage,kind}` Kustomizations and their `*-clusterbook` ApplicationSets in the `argocd` namespace. The AppSets stay dormant (0 Applications) until clusterbook-operator labels a cluster Secret (`network-platform: "true"` + `allocation-ip`, plus `auto-project: "true"` for the per-cluster AppProject).

https://claude.ai/code/session_0183zeU9fk8yZskEgzXUa7Db

---
_Generated by [Claude Code](https://claude.ai/code/session_0183zeU9fk8yZskEgzXUa7Db)_