### PR TITLE
ci(packer): add rocky9 golden/dev to build dispatch options

### DIFF
--- a/.github/workflows/packer-build.yml
+++ b/.github/workflows/packer-build.yml
@@ -18,6 +18,8 @@ on:
         options:
           - golden/sthings-u26
           - dev/u26-dev
+          - golden/sthings-rocky9
+          - dev/rocky9-dev
 
       upload_to_harvester:
         description: "Upload the built image to Harvester"


### PR DESCRIPTION
The manual `workflow_dispatch` `image` choice in `Packer Build` only listed the u26 images, so `golden/sthings-rocky9` and `dev/rocky9-dev` could not be selected to build + upload to Harvester. This adds both to the options list.

After merge, the dropdown on `main` offers all four images, so the Rocky golden can be built and pushed to Harvester via Run workflow with `upload_to_harvester=true`.

https://claude.ai/code/session_011pXwDq9UU2LXJxw5vxZcJG

---
_Generated by [Claude Code](https://claude.ai/code/session_011pXwDq9UU2LXJxw5vxZcJG)_