### PR TITLE
fix(packer): read cloud-init log with sudo in build wait loop

### DIFF
--- a/packer/_build/spec.pkr.hcl
+++ b/packer/_build/spec.pkr.hcl
@@ -50,7 +50,10 @@ build {
   # Wait till Cloud-Init has finished setting up the image on first-boot
   provisioner "shell" {
     inline = [
-      "while [ ! -f /var/lib/cloud/instance/boot-finished ]; do echo 'Waiting for Cloud-Init...'; tail -n10 /var/log/cloud-init-output.log; sleep 5; done"
+      # tail is a diagnostic only; on openSUSE the log is root-only, so read it
+      # with sudo and never let it fail the loop (|| true) — exit is driven solely
+      # by the boot-finished marker. Keeps Ubuntu/Rocky working unchanged.
+      "while [ ! -f /var/lib/cloud/instance/boot-finished ]; do echo 'Waiting for Cloud-Init...'; sudo tail -n10 /var/log/cloud-init-output.log 2>/dev/null || true; sleep 5; done"
     ]
   }
 


### PR DESCRIPTION
## Problem

The `sthings-leap` golden build (run [27166449420](https://github.com/stuttgart-things/harvester/actions/runs/27166449420)) failed. It got past download (checksum OK), boot, and SSH — then died in the shared cloud-init wait provisioner:

```
==> Waiting for Cloud-Init...
tail: cannot open '/var/log/cloud-init-output.log' for reading: Permission denied
Build errored after 41s: Script exited with non-zero exit status: 1. Allowed exit codes are: [0]
```

## Cause

`packer/_build/spec.pkr.hcl` ran `tail -n10 /var/log/cloud-init-output.log` **without `sudo`**. On openSUSE Leap that log is root-only, so `tail` exits 1 and packer aborts the whole build (allowed exit codes `[0]`) before cloud-init even finishes. Ubuntu/Rocky happened to have a readable log, so they passed. The legacy `opensuse-leap/spec.pkr.hcl` used `sudo tail` — that nuance was lost when `_build/` was generalized from the Ubuntu spec.

## Fix

Read the log with `sudo` and make the diagnostic `tail` non-fatal (`|| true`); the loop's exit is driven solely by the `boot-finished` marker. Backward-compatible with the Ubuntu/Rocky builds.

## Blast radius

This touches `packer/_build/`, so the post-merge `Packer Build` rebuilds **all** golden images (u26, rocky9, leap) on a single `kvm` runner — expect them to run sequentially. They should all stay green; leap should now get past the wait loop.

https://claude.ai/code/session_011pXwDq9UU2LXJxw5vxZcJG

---
_Generated by [Claude Code](https://claude.ai/code/session_011pXwDq9UU2LXJxw5vxZcJG)_