### PR TITLE
fix(crossplane-mgmt): supply Vault-PKI annotations for cert-manager

### DIFF
--- a/clusters/crossplane-mgmt/README.md
+++ b/clusters/crossplane-mgmt/README.md
@@ -1,7 +1,7 @@
 
 
 
-kubectl create secret generic crossplane-mgmt   --namespace argocd   --from-file=kubeconfig=/home/sthings/.kube/crossplane-mgmt 
+kubectl create secret generic crossplane-mgmt   --namespace argocd   --from-file=kubeconfig=/home/sthings/.kube/crossplane-mgmt
 secret/crossplane-mgmt created
 
 dagger call -m github.com/stuttgart-things/dagger/sops encrypt   --age-key env:AGE_PUB   --plaintext-file ~/.kube/crossplane-mgmt   --file-extension yaml   export --path=/home/sthings/harvester/secrets/crossplane-mgmt.sthings.lab

--- a/clusters/platform/clusters/crossplane-mgmt.yaml
+++ b/clusters/platform/clusters/crossplane-mgmt.yaml
@@ -22,10 +22,10 @@ spec:
     # cert-manager Vault-PKI ClusterIssuer (appset-cert-manager-vault-pki)
     clusterbook.stuttgart-things.com/vault-server: https://vault.infra.sthings.lab
     clusterbook.stuttgart-things.com/vault-pki-path: pki/sign/sthings-lab
-    clusterbook.stuttgart-things.com/vault-token-secret: cert-manager-vault-token
+    clusterbook.stuttgart-things.com/vault-token-secret: cert-manager-vault-token # pragma: allowlist secret
   labels:                    # stamped onto the resulting ArgoCD cluster secret
     auto-project: "true"     # → cluster-projects makes proj-net-test (required first)
-    network-platform: "true" # → master gate: enables all default-on network 
+    network-platform: "true" # → master gate: enables all default-on network
     network-platform/cilium-lb: 'true'  # → appset-cilium-lb            [ann: ip]
     network-platform/cilium-gateway: 'true'           # → appset-cilium-gateway          [ann: fqdn]
     network-platform/cilium-gateway-secondary: 'false'# → appset-cilium-gateway-secondary [ann: fqdn-secondary]
@@ -34,9 +34,9 @@ spec:
     network-platform/cert-manager-cluster-ca: 'true'  # → appset-cert-manager-cluster-ca  [ann: fqdn, wildcard-issuer-name]
     network-platform/cert-manager-vault-pki: 'true'   # → appset-cert-manager-vault-pki   [ann: vault-server, vault-pki-path, vault-token-secret]
     network-platform/trust-manager-install: 'true'    # → appset-trust-manager-install
-    network-platform/trust-manager-bundle: 'true' 
+    network-platform/trust-manager-bundle: 'true'
     storage-platform: 'true'            # umbrella
-    storage-platform/openebs: 'true'  
+    storage-platform/openebs: 'true'
     storage-platform/longhorn: 'false'  # → appset-longhorn
     storage-platform/nfs-csi-install: 'false'        # → appset-nfs-csi-install (driver + snapshot-controller)
     storage-platform/nfs-csi-storageclasses: 'false' # → appset-nfs-csi-storageclasses (the SC).

--- a/clusters/platform/clusters/crossplane-mgmt.yaml
+++ b/clusters/platform/clusters/crossplane-mgmt.yaml
@@ -18,6 +18,11 @@ spec:
     namespace: argocd
     key: kubeconfig
   releaseOnDelete: true
+  annotations:               # copied onto the ArgoCD cluster Secret; AppSets read config from these
+    # cert-manager Vault-PKI ClusterIssuer (appset-cert-manager-vault-pki)
+    clusterbook.stuttgart-things.com/vault-server: https://vault.infra.sthings.lab
+    clusterbook.stuttgart-things.com/vault-pki-path: pki/sign/sthings-lab
+    clusterbook.stuttgart-things.com/vault-token-secret: cert-manager-vault-token
   labels:                    # stamped onto the resulting ArgoCD cluster secret
     auto-project: "true"     # → cluster-projects makes proj-net-test (required first)
     network-platform: "true" # → master gate: enables all default-on network 


### PR DESCRIPTION
## Problem

`cert-manager-vault-pki-crossplane-mgmt` fails to generate manifests:

```
cert-manager-vault-pki:
- at '/vault/path': minLength: got 0, want 1
- at '/vault/server': '' is not valid uri: relative url
- at '/vault/auth/tokenSecretRef/name': minLength: got 0, want 1
```

The cluster flips `network-platform/cert-manager-vault-pki: 'true'` on, but `crossplane-mgmt.yaml` had **no `annotations:` block**. The `appset-cert-manager-vault-pki` ApplicationSet reads `vault.server` / `path` / `auth.tokenSecretRef.name` from cluster-Secret annotations, so they rendered empty and failed the chart schema (`minLength`, `uri`).

## Fix

Add the three annotations the appset reads, using values derived from this platform's actual Vault config (`clusters/platform/vault/vault.tf`, `clusters/crossplane-mgmt/README.md`):

- `clusterbook.stuttgart-things.com/vault-server: https://vault.infra.sthings.lab`
- `clusterbook.stuttgart-things.com/vault-pki-path: pki/sign/sthings-lab` (PKI role `sthings-lab`)
- `clusterbook.stuttgart-things.com/vault-token-secret: cert-manager-vault-token`

## Note

For the issuer to actually mint certs, the `cert-manager-vault-token` and `vault-pki-ca` Secrets must exist in the `cert-manager` namespace on the cluster (provisioned out-of-band via the `create-vault-issuer` flow in `clusters/crossplane-mgmt/README.md`). This PR resolves the schema/sync failure regardless.

https://claude.ai/code/session_01VDHcHwZHZttCZiZwha9qHh

---
_Generated by [Claude Code](https://claude.ai/code/session_01VDHcHwZHZttCZiZwha9qHh)_