### PR TITLE
feat(crossplane-mgmt): enable cicd-platform (crossplane, tekton, machinery)

### DIFF
--- a/clusters/platform/clusters/crossplane-mgmt.yaml
+++ b/clusters/platform/clusters/crossplane-mgmt.yaml
@@ -25,6 +25,15 @@ spec:
     clusterbook.stuttgart-things.com/vault-token-secret: cert-manager-vault-token # pragma: allowlist secret
   labels:                    # stamped onto the resulting ArgoCD cluster secret
     auto-project: "true"     # → cluster-projects makes proj-net-test (required first)
+    cicd-platform: 'true'                # umbrella: enable the CI/CD stack
+    cicd-platform/crossplane: 'true'     # → appset-crossplane (+ configs/functions/provider-configs/providers)
+    cicd-platform/tekton: 'true'         # → appset-tekton (+ config, dashboard-httproute)
+    cicd-platform/machinery: 'true'      # → machinery-cicd (resource dashboard + gRPC ResourceService)
+    cicd-platform/kro: 'false'           # → appset-kro
+    cicd-platform/dapr: 'false'          # → appset-dapr
+    cicd-platform/kargo: 'false'         # → appset-kargo (+ httproute)
+    cicd-platform/argo-rollouts: 'false' # → appset-argo-rollouts
+    cicd-platform/openebs: 'false'       # → appset-openebs (cicd); using storage-platform/openebs instead (mutually exclusive)
     network-platform: "true" # → master gate: enables all default-on network
     network-platform/cilium-lb: 'true'  # → appset-cilium-lb            [ann: ip]
     network-platform/cilium-gateway: 'true'           # → appset-cilium-gateway          [ann: fqdn]


### PR DESCRIPTION
## What

Enable the `cicd-platform` profile on the `crossplane-mgmt` ClusterbookCluster, opting in to **crossplane**, **tekton**, and **machinery** and explicitly disabling everything else.

| Label | Value | AppSet |
|---|---|---|
| `cicd-platform` (umbrella) | `true` | — |
| `cicd-platform/crossplane` | `true` | `appset-crossplane` (+ configs/functions/provider-configs/providers) |
| `cicd-platform/tekton` | `true` | `appset-tekton` (+ config, dashboard-httproute) |
| `cicd-platform/machinery` | `true` | `machinery-cicd` |
| `cicd-platform/kro` | `false` | `appset-kro` |
| `cicd-platform/dapr` | `false` | `appset-dapr` |
| `cicd-platform/kargo` | `false` | `appset-kargo` (+ httproute) |
| `cicd-platform/argo-rollouts` | `false` | `appset-argo-rollouts` |
| `cicd-platform/openebs` | `false` | `appset-openebs` (cicd) |

## Why openebs is off

`storage-platform/openebs: 'true'` is already set on this cluster, and the cicd vs storage OpenEBS installs are mutually exclusive (single install). So the cicd one stays off.

machinery/crossplane/tekton fan out cleanly here: the cluster already carries `allocation-ip`, `createDNS`/`fqdn`, and `cilium-gateway: 'true'`, which machinery's HTTP/gRPC routes depend on.

Docs for the newly-referenced `cicd-platform/machinery` label are added in a companion PR on `stuttgart-things/argocd`.

https://claude.ai/code/session_01VDHcHwZHZttCZiZwha9qHh

---
_Generated by [Claude Code](https://claude.ai/code/session_01VDHcHwZHZttCZiZwha9qHh)_