### PR TITLE
fix(crossplane-mgmt): issue gateway wildcard cert from vault-pki

### DIFF
--- a/clusters/platform/clusters/crossplane-mgmt.yaml
+++ b/clusters/platform/clusters/crossplane-mgmt.yaml
@@ -23,6 +23,10 @@ spec:
     clusterbook.stuttgart-things.com/vault-server: https://vault.infra.sthings.lab
     clusterbook.stuttgart-things.com/vault-pki-path: pki/sign/sthings-lab
     clusterbook.stuttgart-things.com/vault-token-secret: cert-manager-vault-token # pragma: allowlist secret
+    # Gateway TLS wildcard issuer (appset-cert-manager-cluster-ca): issue the
+    # *.crossplane-mgmt.sthings.lab gateway cert from Vault PKI (trusted root)
+    # instead of the default self-signed cluster-ca.
+    clusterbook.stuttgart-things.com/wildcard-issuer-name: vault-pki
   labels:                    # stamped onto the resulting ArgoCD cluster secret
     auto-project: "true"     # → cluster-projects makes proj-net-test (required first)
     cicd-platform: 'true'                # umbrella: enable the CI/CD stack


### PR DESCRIPTION
## Problem

The cicd platform rolled out on `crossplane-mgmt`, but the gateway TLS cert is wrong: `*.crossplane-mgmt.sthings.lab` (used by `machinery.*` and `tekton.*` HTTPRoutes) is served by `crossplane-mgmt-gateway-tls`, which was issued by the **self-signed-rooted `cluster-ca` ClusterIssuer**.

Root cause: the wildcard cert in `infra/cert-manager/cluster-ca` falls back to the `cluster-ca` issuer (`issuerRef.name | default .Values.ca.name`) unless the cluster supplies `clusterbook.stuttgart-things.com/wildcard-issuer-name`. This cluster never set it, and the cert was minted 16h ago — before `vault-pki` even existed.

## Fix

Add the annotation so `appset-cert-manager-cluster-ca` routes the wildcard through the trusted **`vault-pki`** ClusterIssuer:

```yaml
clusterbook.stuttgart-things.com/wildcard-issuer-name: vault-pki
```

cert-manager re-issues `crossplane-mgmt-gateway-tls` from Vault PKI into the same Secret; the Gateway picks it up automatically. The `vault-pki` ClusterIssuer is already `Ready`.

> Note: assumes the Vault PKI role `sthings-lab` (`pki/sign/sthings-lab`) is allowed to issue for `*.crossplane-mgmt.sthings.lab`. If the role's allowed domains don't cover it, the re-issue will fail and the role needs widening Vault-side.

https://claude.ai/code/session_01VDHcHwZHZttCZiZwha9qHh

---
_Generated by [Claude Code](https://claude.ai/code/session_01VDHcHwZHZttCZiZwha9qHh)_