### PR TITLE
ci(packer): rebuild only changed golden dirs after merge (not all on _build change)

### DIFF
--- a/.github/workflows/packer-build.yml
+++ b/.github/workflows/packer-build.yml
@@ -45,8 +45,10 @@ on:
     branches:
       - main
     paths:
+      # Only a changed golden dir triggers a post-merge rebuild. Shared _build
+      # changes do NOT auto-rebuild every golden (see detect-golden); rebuild
+      # affected images via workflow_dispatch or by touching their dir.
       - "packer/golden/**"
-      - "packer/_build/**"
 
 permissions:
   contents: read
@@ -119,14 +121,13 @@ jobs:
       - name: Detect changed golden images
         id: detect
         run: |
-          # A change under a golden dir rebuilds that golden; a shared _build
-          # change rebuilds ALL golden images.
+          # Rebuild ONLY the golden dirs that changed in this push. A shared
+          # _build change does NOT blanket-rebuild every golden (avoids wasteful
+          # re-uploads when the change is a no-op for most images). If a _build
+          # change must propagate to other images, touch their dir or rebuild
+          # them manually via workflow_dispatch.
           CHANGED=$(git diff --name-only "${{ github.event.before }}" "${{ github.sha }}" || true)
-          if echo "$CHANGED" | grep -q '^packer/_build/'; then
-            DIRS=$(ls -d packer/golden/*/ | sed 's:/*$::' | sort -u)
-          else
-            DIRS=$(echo "$CHANGED" | grep -oP '^packer/golden/[^/]+' | sort -u || true)
-          fi
+          DIRS=$(echo "$CHANGED" | grep -oP '^packer/golden/[^/]+' | sort -u || true)
 
           if [ -z "$DIRS" ]; then
             echo "targets=[]" >> "$GITHUB_OUTPUT"


### PR DESCRIPTION
## Summary

Stop the post-merge `packer-build.yml` from rebuilding + re-uploading **every** golden
image whenever `packer/_build/**` changes. Rebuild **only the golden dirs that actually
changed** in the push.

## Why
`detect-golden` treated any `_build` change as "rebuild ALL golden images". So merging
#106 (which added the opt-in airgap provisioner to `_build`) rebuilt and re-uploaded all
four goldens — and republished every base to S3 — even though the change is a **no-op**
for `sthings-u26` / `sthings-rocky9` / `sthings-leap` (they don't set `airgap_image_tars`).

## Change
- `detect-golden` now rebuilds only the changed `packer/golden/<name>/` dirs; dropped the
  `_build`-change → all-goldens branch.
- Removed `packer/_build/**` from the `push` trigger paths (a `_build`-only push would now
  only produce a no-op detect run).

## Trade-off (accepted)
A genuinely build-affecting shared `_build` change no longer auto-rebuilds every golden —
refresh affected images via `workflow_dispatch` or by touching their dir. Comments in the
workflow call this out.

Unaffected: per-golden rebuilds on a golden-dir change, dev PR build/upload/auto-merge,
and the PR-time `validate` job (still runs on `_build` changes via `packer-pr-build.yml`).

https://claude.ai/code/session_01MoCfLjLpk9DSMXtLF3Gj3h

---
_Generated by [Claude Code](https://claude.ai/code/session_01MoCfLjLpk9DSMXtLF3Gj3h)_