### PR TITLE
fix(argocd): exclude backstage/kustomize files from xrs recurse

### DIFF
--- a/clusters/platform/clusters/platform-crossplane-showcase-apps.yaml
+++ b/clusters/platform/clusters/platform-crossplane-showcase-apps.yaml
@@ -41,6 +41,10 @@ spec:
     path: tests/envs/harvester/crossplane-mgmt/xrs
     directory:
       recurse: true
+      # Skip non-cluster artifacts the scaffolder emits in flux mode:
+      # catalog-info.yaml (Backstage Component) and kustomization.yaml
+      # (kustomize config) are not CRDs — applying them fails the sync.
+      exclude: '{**/catalog-info.yaml,**/kustomization.yaml}'
   destination:
     name: crossplane-mgmt
     namespace: crossplane-system


### PR DESCRIPTION
The `showcase-crossplane-xrs` app syncs with `directory.recurse`, which applies every yaml as a cluster manifest. The scaffolder's flux mode emits `catalog-info.yaml` (Backstage Component) and `kustomization.yaml` (kustomize config) alongside each XR; neither is a CRD, so the sync fails. Exclude both so only real XR manifests are applied.

🤖 Generated with [Claude Code](https://claude.com/claude-code)