### PR TITLE
chore: add xr-ansiblerun + xr-rancher-cluster templates to api profiles

### DIFF
--- a/api-templates-profiles.yaml
+++ b/api-templates-profiles.yaml
@@ -22,6 +22,9 @@ templates:
   - https://raw.githubusercontent.com/stuttgart-things/kcl/refs/heads/main/crossplane/xr-ansiblerun/templates/ansiblerun-minimal.yaml
   - https://raw.githubusercontent.com/stuttgart-things/kcl/refs/heads/main/crossplane/xr-ansiblerun/templates/ansiblerun-baseos.yaml
   - https://raw.githubusercontent.com/stuttgart-things/kcl/refs/heads/main/crossplane/xr-ansiblerun/templates/ansiblerun-detailed.yaml
+  - https://raw.githubusercontent.com/stuttgart-things/kcl/refs/heads/main/crossplane/xr-rancher-cluster/templates/ranchercluster-minimal.yaml
+  - https://raw.githubusercontent.com/stuttgart-things/kcl/refs/heads/main/crossplane/xr-rancher-cluster/templates/ranchercluster-harvester.yaml
+  - https://raw.githubusercontent.com/stuttgart-things/kcl/refs/heads/main/crossplane/xr-rancher-cluster/templates/ranchercluster-detailed.yaml
   - https://raw.githubusercontent.com/stuttgart-things/kcl/refs/heads/main/kubernetes/clusterbook-cluster-gen/templates/clusterbook-cluster-platform.yaml
   - https://raw.githubusercontent.com/stuttgart-things/kcl/refs/heads/main/kubernetes/clusterbook-cluster-gen/templates/clusterbook-cluster-developer.yaml
   - https://raw.githubusercontent.com/stuttgart-things/kcl/refs/heads/main/kubernetes/clusterbook-cluster-gen/templates/clusterbook-cluster-detailed.yaml

--- a/api-templates-profiles.yaml
+++ b/api-templates-profiles.yaml
@@ -19,6 +19,9 @@ templates:
   - https://raw.githubusercontent.com/stuttgart-things/kcl/refs/heads/main/crossplane/xr-virtualmachine/templates/virtualmachine-minimal.yaml
   - https://raw.githubusercontent.com/stuttgart-things/kcl/refs/heads/main/crossplane/xr-virtualmachine/templates/virtualmachine-detailed.yaml
   - https://raw.githubusercontent.com/stuttgart-things/kcl/refs/heads/main/crossplane/xr-virtualmachine/templates/virtualmachine-harvester.yaml
+  - https://raw.githubusercontent.com/stuttgart-things/kcl/refs/heads/main/crossplane/xr-ansiblerun/templates/ansiblerun-minimal.yaml
+  - https://raw.githubusercontent.com/stuttgart-things/kcl/refs/heads/main/crossplane/xr-ansiblerun/templates/ansiblerun-baseos.yaml
+  - https://raw.githubusercontent.com/stuttgart-things/kcl/refs/heads/main/crossplane/xr-ansiblerun/templates/ansiblerun-detailed.yaml
   - https://raw.githubusercontent.com/stuttgart-things/kcl/refs/heads/main/kubernetes/clusterbook-cluster-gen/templates/clusterbook-cluster-platform.yaml
   - https://raw.githubusercontent.com/stuttgart-things/kcl/refs/heads/main/kubernetes/clusterbook-cluster-gen/templates/clusterbook-cluster-developer.yaml
   - https://raw.githubusercontent.com/stuttgart-things/kcl/refs/heads/main/kubernetes/clusterbook-cluster-gen/templates/clusterbook-cluster-detailed.yaml


### PR DESCRIPTION
## Summary

Reference the new KCL ClaimTemplates from `stuttgart-things/kcl` in `api-templates-profiles.yaml` as GitHub raw links:

- **xr-ansiblerun** — `ansiblerun-minimal`, `ansiblerun-baseos`, `ansiblerun-detailed`
- **xr-rancher-cluster** — `ranchercluster-minimal`, `ranchercluster-harvester`, `ranchercluster-detailed`

Both modules are published (`oci://ghcr.io/stuttgart-things/xr-ansiblerun:0.1.0`, `oci://ghcr.io/stuttgart-things/xr-rancher-cluster:0.1.0`) and merged into `kcl` main, so all six raw links resolve.

🤖 Generated with [Claude Code](https://claude.com/claude-code)