### PR TITLE
Update dev image leap-dev (packer)

### DIFF
--- a/packer/dev/leap-dev/catalog-info.yaml
+++ b/packer/dev/leap-dev/catalog-info.yaml
@@ -6,9 +6,6 @@ metadata:
   description: leap-dev self-service dev/playground Packer image, layered on golden sthings-leap
   annotations:
     github.com/project-slug: stuttgart-things/harvester
-    sthings.lab/created-at: '2026-06-08T22:56:49+02:00'
-    sthings.lab/last-modified-by: patrick hermann
-    sthings.lab/last-modified-at: '2026-06-09T20:29:27+02:00'
   tags:
     - harvester
     - packer

--- a/packer/dev/leap-dev/packages-existing.yaml
+++ b/packer/dev/leap-dev/packages-existing.yaml
@@ -1,0 +1,6 @@
+packages:
+  - qemu-guest-agent
+  - vim
+  - curl
+  - git
+  - jq

--- a/packer/dev/leap-dev/users-existing.yaml
+++ b/packer/dev/leap-dev/users-existing.yaml
@@ -1,0 +1,8 @@
+users:
+  - name: sthings
+    groups: wheel
+    shell: /bin/bash
+    sudo: ALL=(ALL) NOPASSWD:ALL # pragma: allowlist secret
+    ssh_authorized_keys:
+      - ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIOoe/pqEulMLsJRxBqgbDtdOftsCHq9K2hU1Xr99FQZA sthings@sthings-air12 # pragma: allowlist secret
+      - ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQCsHiyet7tO+qXYKEy6XBiHNICRfGsBZYIo/JBQ2i16WgkC7rq6bkGwBYtni2j0X2pp0JVtcMO+hthqj37LcGH02hKa24eAoj2UdnFU+bhYxA6Mau1B/5MCkvs8VvBjxtM3FVJE7mY5bZ19YrKJ9ZIosAQaVHiGUu1kk49rzQqMrwT/1PNbUYW19P8J2LsfnaYJIl4Ljbxr0k52MGdbKwgxdph3UKciQz2DhutrmO0gf3Ncn4zpdClldaBtDB0EMMqD3BAtEVsucttzqdeYQwixMTtyuGpAKAJNUqhpleeVhShPZLke0vXxlA6/fyfkSM78gN2FQcRGVPN6hOMkns/b # pragma: allowlist secret


### PR DESCRIPTION
## Dev Packer Image Update (leap-dev)

Self-service dev image layered on golden `sthings-leap`.
Updated via Backstage software template.

On a green build + upload, `packer-pr-build.yml` auto-merges this PR
(unless it also touches a golden image, which forces review).
