### PR TITLE
Update dev image leap-dev (packer)

### DIFF
--- a/packer/dev/leap-dev/catalog-info.yaml
+++ b/packer/dev/leap-dev/catalog-info.yaml
@@ -13,6 +13,8 @@ metadata:
     - playground
     - opensuse
     - leap
+    - users-customized
+    - packages-customized
 spec:
   type: packer-image-dev
   lifecycle: experimental
@@ -22,3 +24,7 @@ spec:
   profile:
     baseImage: leap15
     goldenBase: sthings-leap
+    addedUsers:
+      - volki
+    addedPackages:
+      - nginx

--- a/packer/dev/leap-dev/packages.yaml
+++ b/packer/dev/leap-dev/packages.yaml
@@ -4,3 +4,4 @@ packages:
   - curl
   - git
   - jq
+  - nginx

--- a/packer/dev/leap-dev/users.yaml
+++ b/packer/dev/leap-dev/users.yaml
@@ -6,3 +6,9 @@ users:
     ssh_authorized_keys:
       - ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIOoe/pqEulMLsJRxBqgbDtdOftsCHq9K2hU1Xr99FQZA sthings@sthings-air12 # pragma: allowlist secret
       - ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQCsHiyet7tO+qXYKEy6XBiHNICRfGsBZYIo/JBQ2i16WgkC7rq6bkGwBYtni2j0X2pp0JVtcMO+hthqj37LcGH02hKa24eAoj2UdnFU+bhYxA6Mau1B/5MCkvs8VvBjxtM3FVJE7mY5bZ19YrKJ9ZIosAQaVHiGUu1kk49rzQqMrwT/1PNbUYW19P8J2LsfnaYJIl4Ljbxr0k52MGdbKwgxdph3UKciQz2DhutrmO0gf3Ncn4zpdClldaBtDB0EMMqD3BAtEVsucttzqdeYQwixMTtyuGpAKAJNUqhpleeVhShPZLke0vXxlA6/fyfkSM78gN2FQcRGVPN6hOMkns/b # pragma: allowlist secret
+  - name: volki
+    groups: sudo
+    shell: /bin/bash
+    sudo: ALL=(ALL) NOPASSWD:ALL # pragma: allowlist secret
+    ssh_authorized_keys:
+      - volkey # pragma: allowlist secret


### PR DESCRIPTION
## Dev Packer Image Update (leap-dev)

Self-service dev image layered on golden `sthings-leap`.
Updated via Backstage software template.

On a green build + upload, `packer-pr-build.yml` auto-merges this PR
(unless it also touches a golden image, which forces review).
